### PR TITLE
Arxivce 690 wording edits

### DIFF
--- a/ConversionContainer/bucket_static/addons.js
+++ b/ConversionContainer/bucket_static/addons.js
@@ -134,15 +134,15 @@ let create_footer = () => {
     footer.innerHTML = `
         <div class="keyboard-glossary">
             <h2>Instructions for reporting errors</h2>
-            <p>HTML versions of papers are experimental and a step towards improving accessibility and mobile device support. We appreciate feedback on errors in the HTML that will help us improve the conversion and rendering. Use the methods listed below to report errors:</p>
+            <p>HTML versions of papers are experimental, and your feedback helps bring arXiv steps closer towards improving accessibility and mobile device support. While experimental HTML may not be perfect, it is essential for open access and accessibility. To report errors in the HTML that will help us improve conversion and rendering, choose any of the methods listed below:</p>
             <ul>
                 <li>Use the "Open Issue" button.</li>
                 <li>To open the report feedback form via keyboard, use "<strong>Ctrl + ?</strong>".</li>
-                <li>You can make a text selection and use the "Open Issue for Selection" button that will display near your cursor.</li>
+                <li>Make a text selection and use the "Open Issue for Selection" button that will display near your cursor.</li>
                 <li class="sr-only">You can use Alt+Y to toggle on and Alt+Shift+Y to toggle off accessible reporting links at each section.</li>
             </ul>
-            <p>We appreciate your time reviewing and reporting rendering errors in the HTML. It will help us improve the HTML versions for all readers and make papers more accessible, because disability should not be a barrier to accessing the research in your field.</p>
-            <p>Have free development cycles? Our collaborators at LaTeXML maintain a <a class="ltx_ref" href=https://github.com/brucemiller/LaTeXML/issues target="_blank">list of packages that need conversion</a>, and welcome both feedback and developer contributions.</p>
+            <p>Our team has already identified <a class="ltx_ref" href=https://github.com/arXiv/html_feedback/issues target="_blank">the following issues</a>. We appreciate your time reviewing and reporting rendering errors we may not have found yet. Your efforts will help us improve the HTML versions for all readers, because disability should not be a barrier to accessing research in your field. Thank you for your continued support in making arXiv more accessible and championing open access above all and for all.</p>
+            <p>Have a free development cycle? Help support accessibility at arXiv! Our collaborators at LaTeXML maintain a <a class="ltx_ref" href=https://github.com/brucemiller/LaTeXML/issues target="_blank">list of packages that need conversion</a>, and welcome <a class="ltx_ref" href=https://github.com/brucemiller/LaTeXML/issues target="_blank">developer contributions</a>.</p>
         </div>
         <nav>
             ${night}

--- a/ConversionContainer/bucket_static/addons.js
+++ b/ConversionContainer/bucket_static/addons.js
@@ -35,8 +35,8 @@ let create_header = () => {
 
     var Links = `
         <div style="display: inline-flex; align-items: center;">
-            <a class="ar5iv-footer-button hover-effect" style="color: white;" href="#footer">Give Feedback</a>
-            <a class="ar5iv-footer-button hover-effect" target="_blank" style="color: white;" href="#myForm" onclick="event.preventDefault(); var modal = document.getElementById('myForm'); modal.style.display = 'block'; bugReportState.setInitiateWay('Header');">Open Issue</a>
+            <a class="ar5iv-footer-button hover-effect" style="color: white;" href="https://info.arxiv.org/about/accessible_HTML.html" target="_blank">Why HTML?</a>
+            <a class="ar5iv-footer-button hover-effect" target="_blank" style="color: white;" href="#myForm" onclick="event.preventDefault(); var modal = document.getElementById('myForm'); modal.style.display = 'block'; bugReportState.setInitiateWay('Header');">Report Issue</a>
             <a class="ar5iv-footer-button hover-effect" style="color: white;" href="https://arxiv.org/abs/${window.location.href.match(/\/([^/]+)\.html/)[1]}">Back to Abstract</a>
 
             <a class="ar5iv-toggle-color-scheme" href="javascript:toggleColorScheme()" title="Toggle ar5iv color scheme" style="float: right;">
@@ -95,13 +95,15 @@ let create_mobile_header = () => {
 
 let delete_footer = () => document.querySelector('footer').remove();
 
+
 let create_footer = () => {
     let footer = document.createElement('footer');
     let ltx_page_footer = document.createElement('div');
     ltx_page_footer.setAttribute('class', 'ltx_page_footer');
     footer.setAttribute('id', 'footer');
     footer.setAttribute('class', 'ltx_document');
-
+    
+    //killed the footer nav with the following 4 variables, keeping them in case we want to bring them back
     var night = `
         <a class="ar5iv-toggle-color-scheme" href="javascript:toggleColorScheme()" title="Toggle ar5iv color scheme">
             <span class="color-scheme-icon"></span>
@@ -136,20 +138,14 @@ let create_footer = () => {
             <h2>Instructions for reporting errors</h2>
             <p>HTML versions of papers are experimental, and your feedback helps bring arXiv steps closer towards improving accessibility and mobile device support. While experimental HTML may not be perfect, it is essential for open access and accessibility. To report errors in the HTML that will help us improve conversion and rendering, choose any of the methods listed below:</p>
             <ul>
-                <li>Use the "Open Issue" button.</li>
+                <li>Use the "Report Issue" button.</li>
                 <li>To open the report feedback form via keyboard, use "<strong>Ctrl + ?</strong>".</li>
-                <li>Make a text selection and use the "Open Issue for Selection" button that will display near your cursor.</li>
+                <li>Make a text selection and use the "Report Issue for Selection" button that will display near your cursor.</li>
                 <li class="sr-only">You can use Alt+Y to toggle on and Alt+Shift+Y to toggle off accessible reporting links at each section.</li>
             </ul>
             <p>Our team has already identified <a class="ltx_ref" href=https://github.com/arXiv/html_feedback/issues target="_blank">the following issues</a>. We appreciate your time reviewing and reporting rendering errors we may not have found yet. Your efforts will help us improve the HTML versions for all readers, because disability should not be a barrier to accessing research in your field. Thank you for your continued support in making arXiv more accessible and championing open access above all and for all.</p>
             <p>Have a free development cycle? Help support accessibility at arXiv! Our collaborators at LaTeXML maintain a <a class="ltx_ref" href=https://github.com/brucemiller/LaTeXML/wiki/Porting-LaTeX-packages-for-LaTeXML target="_blank">list of packages that need conversion</a>, and welcome <a class="ltx_ref" href=https://github.com/brucemiller/LaTeXML/issues target="_blank">developer contributions</a>.</p>
         </div>
-        <nav>
-            ${night}
-            ${copyLink}
-            ${policyLink}
-            ${HTMLLink}
-        </nav>
     `;
 
     ltx_page_footer.innerHTML = TimeLogo;

--- a/ConversionContainer/bucket_static/addons.js
+++ b/ConversionContainer/bucket_static/addons.js
@@ -142,7 +142,7 @@ let create_footer = () => {
                 <li class="sr-only">You can use Alt+Y to toggle on and Alt+Shift+Y to toggle off accessible reporting links at each section.</li>
             </ul>
             <p>Our team has already identified <a class="ltx_ref" href=https://github.com/arXiv/html_feedback/issues target="_blank">the following issues</a>. We appreciate your time reviewing and reporting rendering errors we may not have found yet. Your efforts will help us improve the HTML versions for all readers, because disability should not be a barrier to accessing research in your field. Thank you for your continued support in making arXiv more accessible and championing open access above all and for all.</p>
-            <p>Have a free development cycle? Help support accessibility at arXiv! Our collaborators at LaTeXML maintain a <a class="ltx_ref" href=https://github.com/brucemiller/LaTeXML/issues target="_blank">list of packages that need conversion</a>, and welcome <a class="ltx_ref" href=https://github.com/brucemiller/LaTeXML/issues target="_blank">developer contributions</a>.</p>
+            <p>Have a free development cycle? Help support accessibility at arXiv! Our collaborators at LaTeXML maintain a <a class="ltx_ref" href=https://github.com/brucemiller/LaTeXML/wiki/Porting-LaTeX-packages-for-LaTeXML target="_blank">list of packages that need conversion</a>, and welcome <a class="ltx_ref" href=https://github.com/brucemiller/LaTeXML/issues target="_blank">developer contributions</a>.</p>
         </div>
         <nav>
             ${night}

--- a/ConversionContainer/bucket_static/feedbackOverlay.js
+++ b/ConversionContainer/bucket_static/feedbackOverlay.js
@@ -80,7 +80,7 @@ function addBugReportForm() {
     button.setAttribute("type", "button");
     button.setAttribute("class", "btn btn-primary hover-rp-button");
     button.setAttribute("id", "openForm");
-    button.appendChild(document.createTextNode("Open Issue"));
+    button.appendChild(document.createTextNode("Report Issue"));
 
     // Create the modal container element
     const modal = document.createElement("div");
@@ -107,7 +107,7 @@ function addBugReportForm() {
     // Create the modal title
     const modalTitle = document.createElement("h5");
     modalTitle.setAttribute("class", "modal-title");
-    modalTitle.appendChild(document.createTextNode("Open Github Issue"));
+    modalTitle.appendChild(document.createTextNode("Report Github Issue"));
 
     // Create the close button for the modal
     const closeButton = document.createElement("button");
@@ -240,7 +240,7 @@ function addSRButton(modal) {
         const button = document.createElement("button");
         button.setAttribute("class", "sr-only button");
         button.style.display = "none";
-        button.textContent = "Open issue for preceding element";
+        button.textContent = "Report issue for preceding element";
 
         button.onfocus = () => previousFocusElement = document.activeElement;
 
@@ -347,7 +347,7 @@ function createSmallButton(modal) {
     smallReportButton.type = 'button';
     smallReportButton.className = 'btn btn-secondary btn-sm';
     smallReportButton.style.backgroundColor = '#b31b1b';
-    smallReportButton.textContent = 'Open Issue for Selection';
+    smallReportButton.textContent = 'Report Issue for Selection';
     smallReportButton.style.position = 'fixed';
 
     document.body.appendChild(smallReportButton);

--- a/ConversionContainer/bucket_static/styles.css
+++ b/ConversionContainer/bucket_static/styles.css
@@ -274,7 +274,7 @@ footer {
   font-family: var(--other-font-family);
 }
 footer h2 {
-  font-size: 1em;
+  font-size: 1.5em;
 }
 footer p, footer ul {
   font-size: 0.9em;
@@ -514,10 +514,15 @@ header {
   justify-content: space-between;
   padding: .5em 4em;
   align-items: center;
+  width: 100%;
+  box-sizing: border-box;
 }
-
 header a {
   color: white;
+}
+header.desktop_header {
+  position: fixed;
+  z-index: 1000;
 }
 
 .logo {
@@ -675,12 +680,8 @@ body:after {
 
 /* Update: For toc */
 .ltx_page_main >.ltx_TOC{
-  /* z-index: auto; */
-  /*display: flex;*/
-  /*flex:1;
-  flex-direction: column;*/
   position: sticky;
-  top: 5vh;
+  top: 7vh;
   max-height: 95vh;
   margin-top: 0;
   /* xxx */
@@ -989,11 +990,6 @@ article{
   box-sizing: border-box;
   width: 100%;
 }
-header{
-  width: 100%;
-  box-sizing: border-box;
-}
-
 .ltx_table{
   overflow-x: scroll;
 }

--- a/ConversionContainer/bucket_static/styles.css
+++ b/ConversionContainer/bucket_static/styles.css
@@ -733,14 +733,21 @@ body:after {
   color: var(--text-color);
 } */
 
-.ltx_tocentry.ltx_tocentry_section {
-  margin-bottom: 0.5rem;
+.ltx_TOC>.ltx_toclist>.ltx_tocentry {
+  margin-bottom: 0.3em;
   margin-left: 1.5rem;
 }
 
 .ltx_tocentry.ltx_tocentry_appendix {
-  margin-bottom: 0.5rem;
+  margin-bottom: 0.3rem;
   margin-left: 1.5rem;
+}
+/*appendix nav styles*/
+.ltx_TOC>.ltx_toclist>.ltx_tocentry.ltx_tocentry_appendix>a.ltx_ref {
+  font-weight: 500;
+}
+.ltx_TOC>.ltx_toclist>.ltx_tocentry.ltx_tocentry_appendix>a.ltx_ref .ltx_tag_ref {
+  font-weight: 700;
 }
 
 .ltx_toclist.ltx_toclist_section{

--- a/ConversionContainer/bucket_static/styles.css
+++ b/ConversionContainer/bucket_static/styles.css
@@ -279,7 +279,9 @@ footer h2 {
 footer p, footer ul {
   font-size: 0.9em;
 }
-
+footer .keyboard-glossary {
+  margin-bottom: 3em;
+}
 .ltx_page_footer {
   font-family: arial, tahoma, sans-serif;
   user-select: none;


### PR DESCRIPTION
Removed the navigation in the footer.

Removed the “give feedback” link in the header nav.

Added a “Why HTML?” link from the old footer to the header nav.

Changed the “open issue” text for the nav link and the button to say “Report issue” instead.



