### PR TITLE
simplify submission convert calls

### DIFF
--- a/conversion-container/conversion/config.py
+++ b/conversion-container/conversion/config.py
@@ -22,6 +22,7 @@ class Settings(BaseSettings):
     FASTLY_PURGE_KEY: str = "no-key-dev"
     IS_DEV: bool = True
     IS_FULL_CORPUS_CONVERT_MACHINE: bool = False
+    IS_TESTING: bool = False
 
     LOCAL_CONVERSION_DIR = "/arxiv/extracted/"
     LOCAL_PUBLISH_DIR = "/arxiv/publish/"

--- a/conversion-container/conversion/config.py
+++ b/conversion-container/conversion/config.py
@@ -22,7 +22,6 @@ class Settings(BaseSettings):
     FASTLY_PURGE_KEY: str = "no-key-dev"
     IS_DEV: bool = True
     IS_FULL_CORPUS_CONVERT_MACHINE: bool = False
-    IS_TESTING: bool = False
 
     LOCAL_CONVERSION_DIR = "/arxiv/extracted/"
     LOCAL_PUBLISH_DIR = "/arxiv/publish/"

--- a/conversion-container/conversion/domain/conversion.py
+++ b/conversion-container/conversion/domain/conversion.py
@@ -7,7 +7,7 @@ from arxiv.identifier import Identifier
 @dataclass
 class ConversionPayload(ABC):
     identifier: Identifier | int
-    single_file: bool
+    single_file: bool | None
 
     @property
     @abstractmethod
@@ -17,6 +17,7 @@ class ConversionPayload(ABC):
 @dataclass
 class SubmissionConversionPayload(ConversionPayload):
     identifier: int
+    single_file: bool | None
 
     @property
     def name(self) -> str:

--- a/conversion-container/conversion/services/files/__init__.py
+++ b/conversion-container/conversion/services/files/__init__.py
@@ -16,7 +16,8 @@ _doc_src_store: ObjectStore | None = None
 _sub_converted_store: ObjectStore | None = None
 _doc_converted_store: ObjectStore | None = None
 
-def get_global_object_store (path: str, global_name: str) -> ObjectStore:
+
+def get_global_object_store(path: str, global_name: str) -> ObjectStore:
     """Creates an object store from given path."""
     store = globals().get(global_name)
     if store is None:
@@ -29,16 +30,17 @@ def get_global_object_store (path: str, global_name: str) -> ObjectStore:
         globals()[global_name] = store
     return store
 
-def get_file_manager () -> "FileManager":
+
+def get_file_manager() -> "FileManager":
     global _file_manager
     if _file_manager is None:
-        config= current_app.config
+        config = current_app.config
         _file_manager = FileManager(
-            sub_src_store=get_global_object_store(config['SUBMISSION_SOURCE_BUCKET'], '_sub_src_store'),
-            doc_src_store=get_global_object_store(config['DOCUMENT_SOURCE_BUCKET'], '_doc_src_store'),
-            local_conversion_store=get_global_object_store(config['LOCAL_CONVERSION_DIR'], '_local_conversion_store'),
-            local_publish_store=get_global_object_store(config['LOCAL_PUBLISH_DIR'], '_local_publish_store'),
-            sub_converted_store=get_global_object_store(config['SUBMISSION_CONVERTED_BUCKET'], '_sub_converted_store'),
-            doc_converted_store=get_global_object_store(config['DOCUMENT_CONVERTED_BUCKET'], '_doc_converted_store'),
+            sub_src_store=get_global_object_store(config["SUBMISSION_SOURCE_BUCKET"], "_sub_src_store"),
+            doc_src_store=get_global_object_store(config["DOCUMENT_SOURCE_BUCKET"], "_doc_src_store"),
+            local_conversion_store=get_global_object_store(config["LOCAL_CONVERSION_DIR"], "_local_conversion_store"),
+            local_publish_store=get_global_object_store(config["LOCAL_PUBLISH_DIR"], "_local_publish_store"),
+            sub_converted_store=get_global_object_store(config["SUBMISSION_CONVERTED_BUCKET"], "_sub_converted_store"),
+            doc_converted_store=get_global_object_store(config["DOCUMENT_CONVERTED_BUCKET"], "_doc_converted_store"),
         )
     return _file_manager

--- a/conversion-container/conversion/services/files/file_manager.py
+++ b/conversion-container/conversion/services/files/file_manager.py
@@ -58,17 +58,13 @@ class FileManager:
         assert isinstance(local_publish_store, LocalObjectStore)
         self.local_publish_store = local_publish_store
 
-        assert isinstance(sub_converted_store, WritableGSObjectStore)
         self.sub_converted_store = sub_converted_store
 
-        assert isinstance(doc_converted_store, WritableGSObjectStore)
         self.doc_converted_store = doc_converted_store
 
     @retry(stop=stop_after_attempt(6), wait=wait_fixed(10))
     def download_source(self, payload: ConversionPayload) -> tuple[str, LocalFileObj]:
-        """
-        Download the src files and return the main tex file
-        """
+        """Download the src files and return the main tex file."""
         src = self.source_payload_to_file_obj(payload)
 
         with src.open("rb") as ungzip_file:
@@ -123,27 +119,28 @@ class FileManager:
 
     def upload_latexml(self, payload: ConversionPayload) -> None:
         """
-        Upload the latexml and metadata for the given payload. Delete the
-        working directory for the payload after.
+        Upload the latexml and metadata for the given payload.
+
+        Deletes the working directory for the payload after.
         """
         src_dir = self._upload_dir_name(payload)
         if isinstance(payload, DocumentConversionPayload):
-            print(f"Uploading to bucket: {self.doc_converted_store.bucket}")
-            self.doc_converted_store.copy_local_dir(self.latexml_output_dir_name(payload), payload.name)
+            if isinstance(self.doc_converted_store, WritableGSObjectStore):
+                print(f"Uploading to bucket: {self.doc_converted_store.bucket}")
+                self.doc_converted_store.copy_local_dir(self.latexml_output_dir_name(payload), payload.name)
         else:
             destination_fname = f"{src_dir}{payload.name}.tar.gz"
             with tarfile.open(destination_fname, "w:gz") as tar:
                 tar.add(f"{src_dir}/{payload.name}", arcname=str(payload.name))
-            self.sub_converted_store.write_obj(
-                LocalFileObj(Path(destination_fname)), self.sub_converted_store.bucket.blob(f"{payload.name}.tar.gz")
-            )
+            if isinstance(self.sub_converted_store, WritableGSObjectStore):
+                self.sub_converted_store.write_obj(
+                    LocalFileObj(Path(destination_fname)),
+                    self.sub_converted_store.bucket.blob(f"{payload.name}.tar.gz"),
+                )
         self.clean_up_conversion(payload)
 
     def remove_ltxml(self, payload: ConversionPayload) -> None:
-        """
-        Remove files with the .ltxml extension from the working
-        directory of the payload.
-        """
+        """Remove files with the .ltxml extension from the working directory of the payload."""
         for root, _, files in os.walk(self.local_conversion_store.prefix + payload.name):
             for file in files:
                 if str(file).endswith(".ltxml"):
@@ -181,7 +178,8 @@ class FileManager:
     # TODO: refactor so publish and convert can both use
     def upload_document_conversion(self, payload: PublishPayload) -> None:
         # Upload directory back
-        self.doc_converted_store.copy_local_dir(
-            self.local_publish_store.prefix + payload.paper_id.idv, payload.paper_id.idv
-        )
+        if isinstance(self.doc_converted_store, WritableGSObjectStore):
+            self.doc_converted_store.copy_local_dir(
+                self.local_publish_store.prefix + payload.paper_id.idv, payload.paper_id.idv
+            )
         print(f"successfully uploaded to bucket for {payload}")

--- a/conversion-container/conversion/services/files/file_manager.py
+++ b/conversion-container/conversion/services/files/file_manager.py
@@ -1,11 +1,12 @@
 import hashlib
 import os
+import re
 import shutil
 import tarfile
 from io import BytesIO
 from pathlib import Path
 
-from arxiv.files import LocalFileObj, UngzippedFileObj
+from arxiv.files import FileObj, LocalFileObj, UngzippedFileObj
 from arxiv.files.key_patterns import abs_path_current_parent, abs_path_orig_parent
 from arxiv.files.object_store import LocalObjectStore, ObjectStore
 from tenacity import retry, stop_after_attempt, wait_fixed
@@ -21,8 +22,7 @@ from .writable_gs_obj_store import WritableGSObjectStore
 
 
 def sub_src_path(payload: SubmissionConversionPayload) -> str:
-    src_ext = ".gz" if payload.single_file else ".tar.gz"
-    return f"{payload.identifier}/{payload.identifier}{src_ext}"
+    return f"{payload.identifier}/{payload.identifier}.tar.gz"
 
 
 def doc_src_path(payload: DocumentConversionPayload) -> str:
@@ -66,13 +66,10 @@ class FileManager:
 
     @retry(stop=stop_after_attempt(6), wait=wait_fixed(10))
     def download_source(self, payload: ConversionPayload) -> tuple[str, LocalFileObj]:
-        """Download the src files and return the main tex file."""
-        if isinstance(payload, DocumentConversionPayload):
-            src = UngzippedFileObj(self.doc_src_store.to_obj(doc_src_path(payload)))
-            print(f"SOURCE_PATH: {doc_src_path(payload)}")
-        else:
-            assert isinstance(payload, SubmissionConversionPayload)
-            src = UngzippedFileObj(self.sub_src_store.to_obj(sub_src_path(payload)))
+        """
+        Download the src files and return the main tex file
+        """
+        src = self.source_payload_to_file_obj(payload)
 
         with src.open("rb") as ungzip_file:
             input_bytes = ungzip_file.read()
@@ -101,6 +98,22 @@ class FileManager:
         assert isinstance(main_src_obj, LocalFileObj)
 
         return checksum, main_src_obj
+
+    def source_payload_to_file_obj(self, payload: ConversionPayload) -> FileObj:
+        if isinstance(payload, DocumentConversionPayload):
+            return UngzippedFileObj(self.doc_src_store.to_obj(doc_src_path(payload)))
+        else:
+            assert isinstance(payload, SubmissionConversionPayload)
+            sub_path = sub_src_path(payload)
+            store_obj = self.sub_src_store.to_obj(sub_path)
+            if not (store_obj.exists()) and sub_path.endswith(".tar.gz"):
+                sub_path = re.sub(".tar.gz$", ".gz", sub_path)
+                gz_store_obj = self.sub_src_store.to_obj(sub_path)
+                # if we successfully find a .gz, it was a single_file upload, use that.
+                if gz_store_obj.exists():
+                    store_obj = gz_store_obj
+                    payload.single_file = True
+            return UngzippedFileObj(store_obj)
 
     def latexml_output_dir_name(self, payload: ConversionPayload) -> str:
         return f"{self.local_conversion_store.prefix}{payload.name}/html/{payload.name}/"

--- a/conversion-container/pyproject.toml
+++ b/conversion-container/pyproject.toml
@@ -27,9 +27,10 @@ pytest-mock = "*"
 
 [tool.pytest.ini_options]
 markers = [
-  "cc_unit_tests: Unit tests for concurrency control functions",
-  "processing_unit_tests: Unit tests for processing functions",
+  # "cc_unit_tests: Unit tests for concurrency control functions",
+  # "processing_unit_tests: Unit tests for processing functions",
   "logparser_unit_tests: Unit tests for log parser functions",
+  "filestore_unit_tests: Unit tests for filestore operations",
 ]
 filterwarnings = ["ignore:.*google\\._upb\\._message\\..*:DeprecationWarning"]
 

--- a/conversion-container/tests/conftest.py
+++ b/conversion-container/tests/conftest.py
@@ -1,39 +1,46 @@
+import tempfile
+from os.path import abspath, dirname
+
 import pytest
 
 from conversion.factory import create_web_app
+
+package_path = abspath(dirname(dirname(__file__)))
 
 LATEXML_DB_URI = "sqlite:///:memory:?cache=latexml"
 CLASSIC_DATABASE_URI = "sqlite:///:memory:"
 
 TESTING_CONFIG = {
-    "IN_BUCKET_ARXIV_ID": "latexml_arxiv_id_source",
-    "OUT_BUCKET_ARXIV_ID": "latexml_arxiv_id_converted",
-    "OUT_BUCKET_SUB_ID": "latexml_submission_converted",
-    "CLASSIC_DATABASE_URI": "sqlite:///:memory:",
-    "QA_BUCKET_SUB": "latexml_qa_sub",
-    "QA_BUCKET_DOC": "latexml_qa_doc",
+    "QA_BUCKET_SUB": "latexml_qa",
+    "QA_BUCKET_DOC": "gs://latexml_qa_doc",
     "LATEXML_COMMIT": "test_commit_version",
     "LATEXML_DB_URI": LATEXML_DB_URI,
-    "SQLALCHEMY_DATABASE_URI": CLASSIC_DATABASE_URI,
-    "SQLALCHEMY_BINDS": {"latexml": LATEXML_DB_URI},
     "LOCK_DIR": "/arxiv/locks",
+    "SUBMISSION_SOURCE_BUCKET": f"{package_path}/tests/data/",
+    "DOCUMENT_SOURCE_BUCKET": f"{package_path}/tests/data/",
+    "SUBMISSION_CONVERTED_BUCKET": "gs://latexml_submission_converted",
+    "DOCUMENT_CONVERTED_BUCKET": "gs://latexml_arxiv_id_converted",
+    "RAW_LATEXML_SUBMISSION": "gs://raw_latexml_sub_dev",
+    "LATEXML_URL_BASE": "/static/browse/0.3.4",
+    "VIEW_SUB_BASE": "https://services.dev.arxiv.org",
+    "VIEW_DOC_BASE": "https://arxiv-browse-html-6lhtms3oua-uc.a.run.app",
 }
 
 
-def get_test_config():
+def test_config():
     return TESTING_CONFIG.copy()
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
+def test_dir():
+    db_path = tempfile.mkdtemp()
+    yield db_path
+    # shutil.rmtree(db_path)
+
+
+@pytest.fixture(scope="function")
 def app():
-    app = create_web_app(get_test_config())
-    # with app.app_context():
-    #     drop_all()
-    #     create_all()
-    return app
-
-
-@pytest.fixture
-def app_client(app):
+    conf = test_config()
+    app = create_web_app(**conf)
     with app.app_context():
-        yield app.test_client()
+        yield app

--- a/conversion-container/tests/conftest.py
+++ b/conversion-container/tests/conftest.py
@@ -1,4 +1,3 @@
-import tempfile
 from os.path import abspath, dirname
 
 import pytest
@@ -11,31 +10,25 @@ LATEXML_DB_URI = "sqlite:///:memory:?cache=latexml"
 CLASSIC_DATABASE_URI = "sqlite:///:memory:"
 
 TESTING_CONFIG = {
-    "QA_BUCKET_SUB": "latexml_qa",
-    "QA_BUCKET_DOC": "gs://latexml_qa_doc",
+    "QA_BUCKET_SUB": "",
+    "QA_BUCKET_DOC": f"{package_path}/tests/data/",
     "LATEXML_COMMIT": "test_commit_version",
     "LATEXML_DB_URI": LATEXML_DB_URI,
     "LOCK_DIR": "/arxiv/locks",
     "SUBMISSION_SOURCE_BUCKET": f"{package_path}/tests/data/",
     "DOCUMENT_SOURCE_BUCKET": f"{package_path}/tests/data/",
-    "SUBMISSION_CONVERTED_BUCKET": "gs://latexml_submission_converted",
-    "DOCUMENT_CONVERTED_BUCKET": "gs://latexml_arxiv_id_converted",
-    "RAW_LATEXML_SUBMISSION": "gs://raw_latexml_sub_dev",
+    "SUBMISSION_CONVERTED_BUCKET": f"{package_path}/tests/data/",
+    "DOCUMENT_CONVERTED_BUCKET": f"{package_path}/tests/data/",
+    "RAW_LATEXML_SUBMISSION": "",
     "LATEXML_URL_BASE": "/static/browse/0.3.4",
-    "VIEW_SUB_BASE": "https://services.dev.arxiv.org",
-    "VIEW_DOC_BASE": "https://arxiv-browse-html-6lhtms3oua-uc.a.run.app",
+    "VIEW_SUB_BASE": "",
+    "VIEW_DOC_BASE": "",
+    "IS_TESTING": True,
 }
 
 
 def test_config():
     return TESTING_CONFIG.copy()
-
-
-@pytest.fixture(scope="session")
-def test_dir():
-    db_path = tempfile.mkdtemp()
-    yield db_path
-    # shutil.rmtree(db_path)
 
 
 @pytest.fixture(scope="function")

--- a/conversion-container/tests/conftest.py
+++ b/conversion-container/tests/conftest.py
@@ -23,7 +23,6 @@ TESTING_CONFIG = {
     "LATEXML_URL_BASE": "/static/browse/0.3.4",
     "VIEW_SUB_BASE": "",
     "VIEW_DOC_BASE": "",
-    "IS_TESTING": True,
 }
 
 

--- a/conversion-container/tests/test_submission_payload.py
+++ b/conversion-container/tests/test_submission_payload.py
@@ -1,0 +1,21 @@
+import pytest
+from conversion.domain.conversion import SubmissionConversionPayload
+from conversion.services.files import get_file_manager
+
+
+@pytest.mark.filestore_unit_tests
+def test_fetch_tar_gz(app):
+    with app.app_context():
+        manager = get_file_manager()
+        obj = manager.source_payload_to_file_obj(SubmissionConversionPayload(identifier=1234, single_file=None))
+        assert obj.exists()
+        assert obj.name == "1234.tar"
+
+
+@pytest.mark.filestore_unit_tests
+def test_fetch_gz(app):
+    with app.app_context():
+        manager = get_file_manager()
+        obj = manager.source_payload_to_file_obj(SubmissionConversionPayload(identifier=2345, single_file=None))
+        assert obj.exists()
+        assert obj.name == "2345"


### PR DESCRIPTION
Ground work for simpler re-processing calls for submission

- allow a simple `{"submission_id": 1234}` pub/sub message, dropping `single_file` flag for submission requests
- default to `.tar.gz` extension for the submission source path (`sub_src_path`) and fallback to `.gz` if the expected asset wasn't available in the bucket
- revive conftest, add a test  