### PR TITLE
Hide messages about .css and .js inclusions

### DIFF
--- a/conversion-container/conversion/services/latexml/__init__.py
+++ b/conversion-container/conversion/services/latexml/__init__.py
@@ -14,9 +14,12 @@ MISSING_PACKAGE_RE = re.compile(
 )
 
 
-def format_missing_dependency(name: str, message_fragment: str) -> str:
+def format_missing_dependency(name: str, message_fragment: str) -> str | None:
     if name.endswith((".sty", ".cls")):
         return name
+    # Ignore some common low-level issues, this report focuses on the high-level latexml requirements
+    elif name.endswith((".css", ".js", ".tex", ".ltx", ".def")):
+        return None
     else:
         ext = "cls" if message_fragment == "binding for class" else "sty"
         return f"{name}.{ext}"
@@ -24,7 +27,7 @@ def format_missing_dependency(name: str, message_fragment: str) -> str:
 
 def list_missing_packages(latexml_log: str) -> list[str]:
     matches = MISSING_PACKAGE_RE.findall(latexml_log)
-    return list(map(lambda match: format_missing_dependency(match[0], match[1]), matches))
+    return list(filter(None, map(lambda match: format_missing_dependency(match[0], match[1]), matches)))
 
 
 def latexml(payload: ConversionPayload, main_src: LocalFileObj) -> LaTeXMLOutput:

--- a/conversion-container/tests/test_log_parser.py
+++ b/conversion-container/tests/test_log_parser.py
@@ -11,6 +11,8 @@ Warning:missing_file:xifthen Can't find package xifthen
 Warning:missing_file: fail.
 Warning:missing_file:biblatex.sty biblatex.sty is only minimally stubbed and will not be interpreted raw.
 Info:fallback:revtex4-2.cls Interpreted 4-2 as a versioned package/class name, falling back to generic revtex.cls
+Warning:missing_file:/static/browse/0.3.4/css/ar5iv.0.7.9.min.css Couldn't find resource file...
+Warning:missing_file:/static/browse/0.3.4/js/addons_new.js Couldn't find resource file...
 """
     missing_packages = list_missing_packages(latexml_log)
     assert missing_packages == [


### PR DESCRIPTION
My additional checks that also report `.cls` files and stubbed-in `.sty` files picked up a bit too many other missing names (some of which with good internal reasons).

This PR refines the check again, trying to stick to `.sty` and `.cls` reports.

This is a dev.arxiv.org screencap that alerted me to the issue:
<img width="1467" height="605" alt="Screenshot from 2025-07-21 11-36-53" src="https://github.com/user-attachments/assets/78b8e5aa-2afb-49c5-b0cf-05ced3244856" />
