### PR TITLE
[HTML25-179] delegate processing the source directory to LaTeXML

### DIFF
--- a/conversion-container/conversion/processes/convert/__init__.py
+++ b/conversion-container/conversion/processes/convert/__init__.py
@@ -23,13 +23,13 @@ def process(payload: ConversionPayload) -> None:
             lock_str = payload.identifier.idv
         with id_lock(lock_str, current_app.config["LOCK_DIR"]):
             logger.info(f"starting conversion for {payload.identifier}")
-            checksum, main_src = get_file_manager().download_source(payload)
+            checksum, workdir = get_file_manager().download_source(payload)
 
             write_start(payload, checksum)
 
             get_file_manager().remove_ltxml(payload)
 
-            latexml_output = latexml(payload, main_src)  # Also need to upload stdout
+            latexml_output = latexml(payload, workdir)  # Also need to upload stdout
             logger.info(f"Successfully executed latexml on {payload}")
 
             metadata = generate_metadata_convert(payload, latexml_output.missing_packages)

--- a/conversion-container/conversion/services/files/file_manager.py
+++ b/conversion-container/conversion/services/files/file_manager.py
@@ -10,7 +10,6 @@ from arxiv.files import FileObj, LocalFileObj, UngzippedFileObj
 from arxiv.files.key_patterns import abs_path_current_parent, abs_path_orig_parent
 from arxiv.files.object_store import LocalObjectStore, ObjectStore
 from tenacity import retry, stop_after_attempt, wait_fixed
-from tex_inspection import ZeroZeroReadMe, find_primary_tex
 
 from ...domain.conversion import (
     ConversionPayload,
@@ -63,37 +62,25 @@ class FileManager:
         self.doc_converted_store = doc_converted_store
 
     @retry(stop=stop_after_attempt(6), wait=wait_fixed(10))
-    def download_source(self, payload: ConversionPayload) -> tuple[str, LocalFileObj]:
+    def download_source(self, payload: ConversionPayload) -> tuple[str, Path]:
         """Download the src files and return the main tex file."""
         src = self.source_payload_to_file_obj(payload)
+        workdir = Path(self.local_conversion_store.prefix + payload.name)
 
         with src.open("rb") as ungzip_file:
             input_bytes = ungzip_file.read()
             checksum = _get_checksum(input_bytes)
 
         if payload.single_file:
-            with open(f"{self.local_conversion_store.prefix}{payload.name}.tex", "wb+") as local_file:
+            with open(f"{workdir}/{payload.name}.tex", "wb+") as local_file:
                 local_file.write(input_bytes)
+        else:
+            with tarfile.open(fileobj=BytesIO(input_bytes)) as tar:
+                tar.extractall(workdir)
 
-            main_src_obj = self.local_conversion_store.to_obj(f"{payload.name}.tex")
-            assert isinstance(main_src_obj, LocalFileObj)
+        print(f"MAIN WORK DIR: {workdir}, ID: {payload.identifier}")
 
-            return checksum, main_src_obj
-
-        with tarfile.open(fileobj=BytesIO(input_bytes)) as tar:
-            tar.extractall(self.local_conversion_store.prefix + payload.name)
-
-        in_dir = self.local_conversion_store.prefix + payload.name
-        main_src = find_primary_tex(in_dir, ZeroZeroReadMe(in_dir))[0]
-        print(f"MAIN SRC: {main_src}")
-
-        main_src_obj = self.local_conversion_store.to_obj(
-            os.path.relpath(f"{in_dir}/{main_src}", self.local_conversion_store.prefix)
-        )
-        print(f"MAIN SRC OBJ: {main_src_obj}, ID: {payload.identifier}")
-        assert isinstance(main_src_obj, LocalFileObj)
-
-        return checksum, main_src_obj
+        return checksum, workdir
 
     def source_payload_to_file_obj(self, payload: ConversionPayload) -> FileObj:
         if isinstance(payload, DocumentConversionPayload):

--- a/conversion-container/conversion/services/latexml/__init__.py
+++ b/conversion-container/conversion/services/latexml/__init__.py
@@ -1,8 +1,7 @@
 import re
 import subprocess
-from typing import List
+from pathlib import Path
 
-from arxiv.files import LocalFileObj
 from bs4 import BeautifulSoup
 from flask import current_app
 
@@ -30,10 +29,9 @@ def list_missing_packages(latexml_log: str) -> list[str]:
     return list(filter(None, map(lambda match: format_missing_dependency(match[0], match[1]), matches)))
 
 
-def latexml(payload: ConversionPayload, main_src: LocalFileObj) -> LaTeXMLOutput:
+def latexml(payload: ConversionPayload, workdir: Path) -> LaTeXMLOutput:
     LATEXML_URL_BASE = current_app.config["LATEXML_URL_BASE"]
 
-    main_src_path = main_src.item
     output_path = f"{get_file_manager().latexml_output_dir_name(payload)}{payload.name}.html"
 
     latexml_config = [
@@ -57,7 +55,8 @@ def latexml(payload: ConversionPayload, main_src: LocalFileObj) -> LaTeXMLOutput
         f"--javascript={LATEXML_URL_BASE}/js/addons_new.js",
         f"--javascript={LATEXML_URL_BASE}/js/feedbackOverlay.js",
         "--navigationtoc=context",
-        f"--source={main_src_path}",
+        "--whatsin=directory",
+        f"--source={workdir}",
         f"--dest={output_path}",
     ]
 
@@ -71,7 +70,7 @@ def latexml(payload: ConversionPayload, main_src: LocalFileObj) -> LaTeXMLOutput
 
 
 def insert_base_tag(idv: str, html_file_path: str) -> None:
-    """This inserts the base tag into the html so we can use the /html/arxiv_id url."""
+    """Insert the base tag into the html so we can use the /html/arxiv_id url."""
     base_html = f'<base href="/html/{idv}/">'
 
     with open(html_file_path, "r+") as html:
@@ -84,7 +83,7 @@ def insert_base_tag(idv: str, html_file_path: str) -> None:
 
 
 def replace_relative_anchors(absolute_base: str, html_file_path: str) -> None:
-    """This replaces all the relative anchor tags with absolute anchors."""
+    """Replace all the relative anchor tags with absolute anchors."""
     # Note: If this causes bugs, use a SAX parser to do this more accurately
     # while still not needing to completely rebuild the DOM in memory with bs4
     ANCHOR_REGEX = re.compile(r'href="#')


### PR DESCRIPTION
This PR leverages a recent upgrade I added to latexml in [PR #2567](https://github.com/brucemiller/LaTeXML/pull/2567), which leverages both the latest 00README.json metadata, as well as latexml's legacy AutoTeX emulation.

It should minimize the number of wrong main TeX files across the arXiv corpus.