### PR TITLE
[HTML25-177] Testable latexml timeout, streaming use of conversion log

### DIFF
--- a/.github/workflows/conversion-container-pytest.yml
+++ b/.github/workflows/conversion-container-pytest.yml
@@ -15,12 +15,15 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
-
+    env:
+      LATEXML_COMMIT: "5e47b3b13a386826581a31464083086520ca2817"
     steps:
-      - name: Install a generic LaTeXML
+      - name: Install a recent LaTeXML
         run: |
-          sudo apt-get -q update
-          sudo apt-get -qy install latexml
+          eval $(perl -I$HOME/perl5/lib -Mlocal::lib)
+          echo 'eval "$(perl -I$HOME/perl5/lib/perl5 -Mlocal::lib)"' >> ~/.bashrc
+          cpanm --notest --verbose https://github.com/brucemiller/LaTeXML/tarball/$LATEXML_COMMIT
+
       - uses: actions/checkout@v3
       - name: Set up Python
         uses: actions/setup-python@v3

--- a/.github/workflows/conversion-container-pytest.yml
+++ b/.github/workflows/conversion-container-pytest.yml
@@ -16,13 +16,17 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      LATEXML_COMMIT: "5e47b3b13a386826581a31464083086520ca2817"
+      LATEXML_COMMIT: 5e47b3b13a386826581a31464083086520ca2817
+      TMPDIR: /tmp
     steps:
-      - name: Install a recent LaTeXML
+      - name: Install a generic LaTeXML
         run: |
-          eval $(perl -I$HOME/perl5/lib -Mlocal::lib)
-          echo 'eval "$(perl -I$HOME/perl5/lib/perl5 -Mlocal::lib)"' >> ~/.bashrc
-          cpanm --notest --verbose https://github.com/brucemiller/LaTeXML/tarball/$LATEXML_COMMIT
+          sudo apt update
+          sudo apt install cpanminus libarchive-zip-perl libdb-dev libfile-which-perl \
+            libimage-magick-perl libimage-size-perl libio-string-perl libjson-xs-perl \
+            libparse-recdescent-perl libtext-unidecode-perl liburi-perl libuuid-tiny-perl \
+            libwww-perl libxml-libxml-perl libxml-libxslt-perl libxml2-dev libxslt1-dev
+          cpanm --sudo --notest --verbose https://github.com/brucemiller/LaTeXML/archive/${LATEXML_COMMIT}.zip
 
       - uses: actions/checkout@v3
       - name: Set up Python

--- a/.github/workflows/conversion-container-pytest.yml
+++ b/.github/workflows/conversion-container-pytest.yml
@@ -17,6 +17,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Install a generic LaTeXML
+        run: |
+          sudo apt-get -q update
+          sudo apt-get -qy install latexml
       - uses: actions/checkout@v3
       - name: Set up Python
         uses: actions/setup-python@v3

--- a/conversion-container/Dockerfile
+++ b/conversion-container/Dockerfile
@@ -1,6 +1,8 @@
 # syntax=docker/dockerfile:1
 
-# This dockerfile is for doing full corpus convert.
+# DG: This dockerfile is deprecated.
+#
+# This dockerfile was for doing full corpus convert.
 # It needs to be run with the correct environment
 # variables and google application credentials
 

--- a/conversion-container/conversion/domain/conversion.py
+++ b/conversion-container/conversion/domain/conversion.py
@@ -40,5 +40,6 @@ class DocumentConversionPayload(ConversionPayload):
 
 @dataclass
 class LaTeXMLOutput:
-    output: str
+    returncode: int
+    log: str | None
     missing_packages: list[str]

--- a/conversion-container/conversion/processes/convert/__init__.py
+++ b/conversion-container/conversion/processes/convert/__init__.py
@@ -37,8 +37,9 @@ def process(payload: ConversionPayload) -> None:
 
             with open(f"{get_file_manager().latexml_output_dir_name(payload)}__metadata.json", "w") as f:
                 f.write(metadata)
-            with open(f"{get_file_manager().latexml_output_dir_name(payload)}__stdout.txt", "w") as f:
-                f.write(latexml_output.output)
+            # This is now written by the main latexml process, see the --log parameter.
+            # with open(f"{get_file_manager().latexml_output_dir_name(payload)}__stdout.txt", "w") as f:
+            #     f.write(latexml_output.output)
 
             if isinstance(payload, DocumentConversionPayload):
                 main_html_file_path = f"{get_file_manager().latexml_output_dir_name(payload)}{payload.name}.html"

--- a/conversion-container/conversion/services/latexml/__init__.py
+++ b/conversion-container/conversion/services/latexml/__init__.py
@@ -47,8 +47,10 @@ def latexml(payload: ConversionPayload, workdir: Path) -> LaTeXMLOutput:
         ],
     )
     LATEXML_PRELOADS = current_app.config.get("LATEXML_PRELOADS", ["ar5iv.sty"])
-    LATEXML_LOG_FILE = current_app.config.get("LATEXML_LOG_FILE", f"{workdir}/__stdout.txt")
-    output_path = f"{get_file_manager().latexml_output_dir_name(payload)}{payload.name}.html"
+    LATEXML_LOG_FILE = current_app.config.get("LATEXML_LOG_FILE", "__stdout.txt")
+    output_dirname = get_file_manager().latexml_output_dir_name(payload)
+    output_path = f"{output_dirname}{payload.name}.html"
+    log_path = f"{output_dirname}{LATEXML_LOG_FILE}"
 
     latexml_config = [
         "latexmlc",
@@ -70,7 +72,7 @@ def latexml(payload: ConversionPayload, workdir: Path) -> LaTeXMLOutput:
         "--navigationtoc=context",
         "--whatsin=directory",
         f"--source={workdir}",
-        f"--log={LATEXML_LOG_FILE}",
+        f"--log={log_path}",
         f"--dest={output_path}",
     ]
     for preload in LATEXML_PRELOADS:

--- a/conversion-container/conversion/services/latexml/__init__.py
+++ b/conversion-container/conversion/services/latexml/__init__.py
@@ -1,3 +1,4 @@
+import logging
 import re
 import subprocess
 from pathlib import Path
@@ -24,26 +25,38 @@ def format_missing_dependency(name: str, message_fragment: str) -> str | None:
         return f"{name}.{ext}"
 
 
-def list_missing_packages(latexml_log: str) -> list[str]:
-    matches = MISSING_PACKAGE_RE.findall(latexml_log)
-    return list(filter(None, map(lambda match: format_missing_dependency(match[0], match[1]), matches)))
+def list_missing_packages(latexml_log_path: Path) -> list[str]:
+    matches = []
+    if latexml_log_path.exists():
+        with open(latexml_log_path) as latexml_log_stream:
+            for line in latexml_log_stream:
+                match = re.search(MISSING_PACKAGE_RE, line)
+                if match:
+                    matches.append(match)
+    return list(filter(None, map(lambda match: format_missing_dependency(match[1], match[2]), matches)))
 
 
 def latexml(payload: ConversionPayload, workdir: Path) -> LaTeXMLOutput:
     LATEXML_URL_BASE = current_app.config["LATEXML_URL_BASE"]
-
+    LATEXML_TIMEOUT_SEC = current_app.config.get("LATEXML_TIMEOUT_SEC", 600)
+    LATEXML_PATHS = current_app.config.get(
+        "LATEXML_PATHS",
+        [
+            "/opt/ar5iv-bindings/bindings",
+            "/opt/ar5iv-bindings/supported_originals",
+        ],
+    )
+    LATEXML_PRELOADS = current_app.config.get("LATEXML_PRELOADS", ["ar5iv.sty"])
+    LATEXML_LOG_FILE = current_app.config.get("LATEXML_LOG_FILE", f"{workdir}/__stdout.txt")
     output_path = f"{get_file_manager().latexml_output_dir_name(payload)}{payload.name}.html"
 
     latexml_config = [
         "latexmlc",
         "--preload=[nobibtex,nobreakuntex,localrawstyles,mathlexemes,magnify=1.2,zoomout=1.2,tokenlimit=249999999,iflimit=3599999,absorblimit=1299999,pushbacklimit=599999]latexml.sty",
-        "--preload=ar5iv.sty",
-        "--path=/opt/ar5iv-bindings/bindings",
-        "--path=/opt/ar5iv-bindings/supported_originals",
         "--pmml",
         "--mathtex",
         "--noinvisibletimes",
-        "--timeout=600",
+        f"--timeout={LATEXML_TIMEOUT_SEC}",
         "--nodefaultresources",
         "--format=html5",
         "--css=https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css",
@@ -57,15 +70,30 @@ def latexml(payload: ConversionPayload, workdir: Path) -> LaTeXMLOutput:
         "--navigationtoc=context",
         "--whatsin=directory",
         f"--source={workdir}",
+        f"--log={LATEXML_LOG_FILE}",
         f"--dest={output_path}",
     ]
-
-    completed_process = subprocess.run(
-        latexml_config, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, check=True, text=True, timeout=500
-    )
-
+    for preload in LATEXML_PRELOADS:
+        latexml_config.append(f"--preload={preload}")
+    for path in LATEXML_PATHS:
+        latexml_config.append(f"--path={path}")
+    try:
+        completed_process = subprocess.run(
+            latexml_config, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, check=True, text=True, timeout=500
+        )
+        returncode = completed_process.returncode
+    except subprocess.TimeoutExpired as e:
+        logging.warning(f"LaTeXML conversion timed out after {e.timeout} seconds")
+        returncode = 1
+    except Exception as e:
+        logging.warning(f"LaTeXML conversion failed with error {e}")
+        returncode = 1
+    # Note: latexml will write the full conversion log at the path specified by `--log=[path]`,
+    # so we can keep the current __stdout.txt convention for now by copying the deposited log.
     return LaTeXMLOutput(
-        output=completed_process.stdout, missing_packages=list_missing_packages(completed_process.stdout)
+        missing_packages=list_missing_packages(Path(LATEXML_LOG_FILE)),
+        log=None,  # use the file from --log
+        returncode=returncode,
     )
 
 

--- a/conversion-container/pyproject.toml
+++ b/conversion-container/pyproject.toml
@@ -31,6 +31,7 @@ markers = [
   # "processing_unit_tests: Unit tests for processing functions",
   "logparser_unit_tests: Unit tests for log parser functions",
   "filestore_unit_tests: Unit tests for filestore operations",
+  "call_latexml_tests: Tests the stability of latexml calls",
 ]
 filterwarnings = ["ignore:.*google\\._upb\\._message\\..*:DeprecationWarning"]
 

--- a/conversion-container/tests/test_call_latexml.py
+++ b/conversion-container/tests/test_call_latexml.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 
 from conversion.domain.conversion import LaTeXMLOutput, SubmissionConversionPayload
+from conversion.services.files import get_file_manager
 from conversion.services.latexml import latexml
 
 
@@ -14,16 +15,19 @@ def call_bare_latexml(app, config=dict | None) -> LaTeXMLOutput:
         with tempfile.TemporaryDirectory() as workdir:
             app.config["LOCAL_CONVERSION_DIR"] = workdir
             app.config["LOCAL_PUBLISH_DIR"] = f"{workdir}/html"
-            app.config["LATEXML_LOG_FILE"] = f"{workdir}/__stdout.txt"
+            app.config["LATEXML_LOG_FILE"] = "__stdout.txt"
             # Empty, we do not have the dockerized ar5iv additions here
             app.config["LATEXML_PATHS"] = []
             app.config["LATEXML_PRELOADS"] = []
             for key, value in config.items():
                 app.config[key] = value
-            latexml_log_path = Path(app.config["LATEXML_LOG_FILE"])
             with open(f"{workdir}/test.tex", "w") as file:
                 file.write(config["TEST_TEX_CONTENT"])
-            result = latexml(SubmissionConversionPayload(identifier=123, single_file=None), Path(workdir))
+            payload = SubmissionConversionPayload(identifier=123, single_file=None)
+            output_dirname = get_file_manager().latexml_output_dir_name(payload)
+            result = latexml(payload, Path(workdir))
+
+            latexml_log_path = Path(output_dirname + app.config["LATEXML_LOG_FILE"])
             assert latexml_log_path.exists()
             with open(latexml_log_path) as latexml_log_file:
                 result.log = latexml_log_file.read()

--- a/conversion-container/tests/test_call_latexml.py
+++ b/conversion-container/tests/test_call_latexml.py
@@ -1,0 +1,42 @@
+import logging
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from conversion.domain.conversion import LaTeXMLOutput, SubmissionConversionPayload
+from conversion.services.latexml import latexml
+
+
+def call_bare_latexml(app, config=dict | None) -> LaTeXMLOutput:
+    """Call bare latexml without any additional configuration (no ar5iv paths or additions)."""
+    with app.app_context():
+        with tempfile.TemporaryDirectory() as workdir:
+            app.config["LOCAL_CONVERSION_DIR"] = workdir
+            app.config["LOCAL_PUBLISH_DIR"] = f"{workdir}/html"
+            app.config["LATEXML_LOG_FILE"] = f"{workdir}/__stdout.txt"
+            # Empty, we do not have the dockerized ar5iv additions here
+            app.config["LATEXML_PATHS"] = []
+            app.config["LATEXML_PRELOADS"] = []
+            for key, value in config.items():
+                app.config[key] = value
+            latexml_log_path = Path(app.config["LATEXML_LOG_FILE"])
+            with open(f"{workdir}/test.tex", "w") as file:
+                file.write(config["TEST_TEX_CONTENT"])
+            result = latexml(SubmissionConversionPayload(identifier=123, single_file=None), Path(workdir))
+            assert latexml_log_path.exists()
+            with open(latexml_log_path) as latexml_log_file:
+                result.log = latexml_log_file.read()
+            return result
+
+
+@pytest.mark.call_latexml_tests
+def test_latexml_timeout(app):
+    config = {
+        "LATEXML_TIMEOUT_SEC": 1,
+        "TEST_TEX_CONTENT": r"\def\oops{test \oops here}\oops\bye",
+    }
+    result = call_bare_latexml(app, config)
+    logging.warning(f"RESULT: {result}")
+    assert "Fatal:timeout:timedout" in result.log
+    assert result.returncode == 1

--- a/conversion-container/tests/test_log_parser.py
+++ b/conversion-container/tests/test_log_parser.py
@@ -1,3 +1,7 @@
+import os
+import tempfile
+from pathlib import Path
+
 import pytest
 
 from conversion.services.latexml import list_missing_packages
@@ -5,7 +9,7 @@ from conversion.services.latexml import list_missing_packages
 
 @pytest.mark.logparser_unit_tests
 def test_find_package_and_class():
-    latexml_log = """
+    latexml_log = b"""
 Warning:missing_file:imsart Can't find binding for class imsart (using OmniBus)
 Warning:missing_file:xifthen Can't find package xifthen
 Warning:missing_file: fail.
@@ -14,7 +18,11 @@ Info:fallback:revtex4-2.cls Interpreted 4-2 as a versioned package/class name, f
 Warning:missing_file:/static/browse/0.3.4/css/ar5iv.0.7.9.min.css Couldn't find resource file...
 Warning:missing_file:/static/browse/0.3.4/js/addons_new.js Couldn't find resource file...
 """
-    missing_packages = list_missing_packages(latexml_log)
+    log_tmpfile = tempfile.NamedTemporaryFile(delete=False)
+    log_tmpfile.write(latexml_log)
+    log_tmpfile.close()
+    missing_packages = list_missing_packages(Path(log_tmpfile.name))
+    os.remove(log_tmpfile.name)
     assert missing_packages == [
         "imsart.cls",
         "xifthen.sty",


### PR DESCRIPTION
This PR rearranges some config parameters to allow testing a latexml timeout (set to 1 second) is correctly recognized and recorded.

In the course of doing that I spotted some easy efficiency wins by using the `--log` parameter of latexml, writing the log information in the work directory, and then doing a streaming scan for the reported `missing_file` messages.

Gets us one more step closer to the ar5iv build system.