### PR TITLE
[HTML25-177] Guard: ensure stale assets are cleaned up before latexml is called

### DIFF
--- a/conversion-container/conversion/services/latexml/__init__.py
+++ b/conversion-container/conversion/services/latexml/__init__.py
@@ -1,6 +1,9 @@
 import logging
+import os
 import re
+import shutil
 import subprocess
+import time
 from pathlib import Path
 
 from bs4 import BeautifulSoup
@@ -12,6 +15,8 @@ from ..files import get_file_manager
 MISSING_PACKAGE_RE = re.compile(
     r"^Warning:missing_file:(\S+)\s(?:Can't\sfind\s(package|binding for class))?", flags=re.MULTILINE
 )
+TMPDIR = Path(os.getenv("TMPDIR", "/tmp"))
+UID = os.getuid()
 
 
 def format_missing_dependency(name: str, message_fragment: str) -> str | None:
@@ -36,9 +41,31 @@ def list_missing_packages(latexml_log_path: Path) -> list[str]:
     return list(filter(None, map(lambda match: format_missing_dependency(match[1], match[2]), matches)))
 
 
+def clean_up_stale_assets(tmpdir: Path, stale_asset_expiration_sec: int) -> None:
+    """
+    Clean the temporary directory from all files that have are now stale (too old).
+
+    When latexml dies in particularly dirty ways (e.g. imagemagick issues) the initial
+    web service process may become completely unrecoverable. In these cases files can remain
+    in the temporary directory for an indefinite amount of time, and fill up the disk.
+    """
+    now = time.time()
+    # Always try to clean up old / unneeded files.
+    for entry in os.listdir(tmpdir):
+        full_entry = os.path.join(tmpdir, entry)
+        stat = os.stat(full_entry)
+        # only consider old files this user owns.
+        age = now - stat.st_mtime
+        if stat.st_uid == UID and (age > stale_asset_expiration_sec):
+            logging.warning(f"deleting stale temporary asset ({age}s): {full_entry}")
+            if os.path.isfile(full_entry):
+                os.remove(full_entry)
+            else:
+                shutil.rmtree(full_entry)
+
+
 def latexml(payload: ConversionPayload, workdir: Path) -> LaTeXMLOutput:
     LATEXML_URL_BASE = current_app.config["LATEXML_URL_BASE"]
-    LATEXML_TIMEOUT_SEC = current_app.config.get("LATEXML_TIMEOUT_SEC", 600)
     LATEXML_PATHS = current_app.config.get(
         "LATEXML_PATHS",
         [
@@ -48,6 +75,15 @@ def latexml(payload: ConversionPayload, workdir: Path) -> LaTeXMLOutput:
     )
     LATEXML_PRELOADS = current_app.config.get("LATEXML_PRELOADS", ["ar5iv.sty"])
     LATEXML_LOG_FILE = current_app.config.get("LATEXML_LOG_FILE", "__stdout.txt")
+    LATEXML_TIMEOUT_SEC = int(current_app.config.get("LATEXML_TIMEOUT_SEC", 600))
+    # Always clean up before executing the latexml call, this is too important
+    # for service health, so we tightly couple it with this call.
+    # (at least for now)
+    #
+    # Assets are considered stale 5 min after a fully timed latexml run is over.
+    stale_asset_expiration_sec = 300 + LATEXML_TIMEOUT_SEC
+    clean_up_stale_assets(TMPDIR, stale_asset_expiration_sec)
+
     output_dirname = get_file_manager().latexml_output_dir_name(payload)
     output_path = f"{output_dirname}{payload.name}.html"
     log_path = f"{output_dirname}{LATEXML_LOG_FILE}"

--- a/conversion-container/tests/test_call_latexml.py
+++ b/conversion-container/tests/test_call_latexml.py
@@ -1,12 +1,14 @@
 import logging
+import os
 import tempfile
+import time
 from pathlib import Path
 
 import pytest
 
 from conversion.domain.conversion import LaTeXMLOutput, SubmissionConversionPayload
 from conversion.services.files import get_file_manager
-from conversion.services.latexml import latexml
+from conversion.services.latexml import clean_up_stale_assets, latexml
 
 
 def call_bare_latexml(app, config=dict | None) -> LaTeXMLOutput:
@@ -44,3 +46,19 @@ def test_latexml_timeout(app):
     logging.warning(f"RESULT: {result}")
     assert "Fatal:timeout:timedout" in result.log
     assert result.returncode == 1
+
+
+@pytest.mark.call_latexml_tests
+def test_clean_up_stale_assets(app):
+    with tempfile.TemporaryDirectory() as workdir:
+        test_file_path = f"{workdir}/test.tex"
+        with open(test_file_path, "w") as file:
+            file.write("sample")
+        test_dir_path = f"{workdir}/test_dir"
+        os.mkdir(f"{workdir}/test_dir")
+        time.sleep(1)
+        assert os.path.exists(test_file_path)
+        assert os.path.exists(test_dir_path)
+        clean_up_stale_assets(workdir, 0)
+        assert not (os.path.exists(test_file_path))
+        assert not (os.path.exists(test_dir_path))


### PR DESCRIPTION
This PR adds a check at the beginning of any call to latexml which will detect stale temporary assets and delete them.

This is very much needed as latexml has failure conditions that lead to unrecoverable process exits (imagemagick/ghostscript is the usual offender). Especially when the problem is due to image conversion, large temporary assets can remain on the filesystem, eventually leading to running out of space.