### PR TITLE
[HTML25-177] ensure the latexml timeout will trigger before the subprocess

### DIFF
--- a/conversion-container/conversion/services/latexml/__init__.py
+++ b/conversion-container/conversion/services/latexml/__init__.py
@@ -117,7 +117,12 @@ def latexml(payload: ConversionPayload, workdir: Path) -> LaTeXMLOutput:
         latexml_config.append(f"--path={path}")
     try:
         completed_process = subprocess.run(
-            latexml_config, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, check=True, text=True, timeout=500
+            latexml_config,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            check=True,
+            text=True,
+            timeout=LATEXML_TIMEOUT_SEC + 5,
         )
         returncode = completed_process.returncode
     except subprocess.TimeoutExpired as e:


### PR DESCRIPTION
A subtlety while testing - the timeout of the subprocess call should be a little larger than the latexml timeout, to allow clean logging from the inner process to complete.