### PR TITLE
[HTML25-177] only write success if latexml return code is 0

### DIFF
--- a/conversion-container/conversion/processes/convert/__init__.py
+++ b/conversion-container/conversion/processes/convert/__init__.py
@@ -48,9 +48,11 @@ def process(payload: ConversionPayload) -> None:
                     f'{current_app.config["VIEW_DOC_BASE"]}/html/{payload.identifier.idv}', main_html_file_path
                 )
                 logger.info(f"Successfully updated HTML for {payload}")
-
-            write_success(payload, checksum)
-            logger.info(f"Successfully wrote {payload} to announced DB")
+            if latexml_output.returncode == 0:
+                write_success(payload, checksum)
+                logger.info(f"Successfully wrote {payload} to announced DB")
+            else:
+                write_failure(payload, checksum)
 
             # Note: There is a gap between when the user would see that html is ready and when it is uploaded.
             # In my opinion, this is a smaller problem than the user seeing an incorrect version of their html


### PR DESCRIPTION
Now that we don't throw exceptions for timeouts but collect a return code, inform the DB of success only if latexml exits with 0.