### PR TITLE
[patch] Direct convert of announced gz papers; remove math annotation

### DIFF
--- a/conversion-container/conversion/services/files/file_manager.py
+++ b/conversion-container/conversion/services/files/file_manager.py
@@ -66,7 +66,7 @@ class FileManager:
         """Download the src files and return the main tex file."""
         src = self.source_payload_to_file_obj(payload)
         workdir = Path(self.local_conversion_store.prefix + payload.name)
-
+        os.makedirs(workdir, exist_ok=True)
         with src.open("rb") as ungzip_file:
             input_bytes = ungzip_file.read()
             checksum = _get_checksum(input_bytes)

--- a/conversion-container/conversion/services/latexml/__init__.py
+++ b/conversion-container/conversion/services/latexml/__init__.py
@@ -99,7 +99,7 @@ def latexml(payload: ConversionPayload, workdir: Path) -> LaTeXMLOutput:
 
     latexml_config = [
         "latexmlc",
-        "--preload=[nobibtex,nobreakuntex,localrawstyles,mathlexemes,magnify=1.2,zoomout=1.2,tokenlimit=249999999,iflimit=3599999,absorblimit=1299999,pushbacklimit=599999]latexml.sty",
+        "--preload=[nobibtex,nobreakuntex,localrawstyles,magnify=1.2,zoomout=1.2,tokenlimit=249999999,iflimit=3599999,absorblimit=1299999,pushbacklimit=599999]latexml.sty",
         "--pmml",
         "--mathtex",
         "--noinvisibletimes",


### PR DESCRIPTION
This small PR ensures a directory is created before we unpack a gz archive in it.

I also removed an experimental math output (which no one ever used) that got overlooked from my option revising earlier.