### PR TITLE
update to velocity fork of latexml, as of 12.2025

### DIFF
--- a/conversion-container/conversion/services/latexml/__init__.py
+++ b/conversion-container/conversion/services/latexml/__init__.py
@@ -99,7 +99,6 @@ def latexml(payload: ConversionPayload, workdir: Path) -> LaTeXMLOutput:
 
     latexml_config = [
         "latexmlc",
-        "--preload=[nobibtex,nobreakuntex,rawstyles,magnify=1.2,zoomout=1.2,tokenlimit=249999999,iflimit=3999999,absorblimit=1299999,pushbacklimit=599999]latexml.sty",
         "--pmml",
         "--mathtex",
         "--noinvisibletimes",

--- a/conversion-container/dockerfiles/Dockerfile.ar5ivist_base
+++ b/conversion-container/dockerfiles/Dockerfile.ar5ivist_base
@@ -58,7 +58,7 @@ RUN eval $(perl -I$HOME/perl5/lib -Mlocal::lib)
 RUN echo 'eval "$(perl -I$HOME/perl5/lib/perl5 -Mlocal::lib)"' >> ~/.bashrc
 
 # Collect the extended ar5iv-bindings files
-ENV AR5IV_BINDINGS_COMMIT=847b4835448d17065d612c04b52c4a373ec0fd15
+ENV AR5IV_BINDINGS_COMMIT=14d0e8faa9bddb128a00ce298b6c2f5c8445e654
 RUN rm -rf /opt/ar5iv-bindings
 RUN git clone https://github.com/dginev/ar5iv-bindings /opt/ar5iv-bindings
 WORKDIR /opt/ar5iv-bindings
@@ -67,8 +67,8 @@ RUN git reset --hard $AR5IV_BINDINGS_COMMIT
 # Install LaTeXML, at a fixed commit, via cpanminus
 RUN mkdir -p /opt/latexml
 WORKDIR /opt/latexml
-ENV LATEXML_COMMIT=25ec2b0e9070cc05cbb5e5e22bebf5ba98a0d86c
-RUN cpanm --notest --verbose --build-args formats https://github.com/brucemiller/LaTeXML/archive/${LATEXML_COMMIT}.zip
+ENV LATEXML_COMMIT=d2198ae09bc7037b987b8cf6247967ab40fd960a
+RUN cpanm --notest --verbose --build-args formats https://github.com/arXiv/LaTeXML/archive/${LATEXML_COMMIT}.zip
 
 # Enable imagemagick policy permissions for work with arXiv PDF/EPS files
 RUN perl -pi.bak -e 's/rights="none" pattern="([XE]?PS\d?|PDF)"/rights="read|write" pattern="$1"/g' /etc/ImageMagick-6/policy.xml


### PR DESCRIPTION
This updates us to the latest available features in LaTeXML's ecosystem.

Summary of the latexml changes so far is at:
https://github.com/arXiv/LaTeXML/blob/master/ARXIV_CHANGELOG.md

I would like to see how the new builds go and test a few articles in dev. The finall commit will likely be different, still finalizing some patches from the sandbox testing.