### PR TITLE
update to final latexml preview commits

### DIFF
--- a/conversion-container/conversion/services/latexml/__init__.py
+++ b/conversion-container/conversion/services/latexml/__init__.py
@@ -103,7 +103,6 @@ def latexml(payload: ConversionPayload, workdir: Path) -> LaTeXMLOutput:
         "--mathtex",
         "--noinvisibletimes",
         f"--timeout={LATEXML_TIMEOUT_SEC}",
-        "--nodefaultresources",
         "--format=html5",
         f"--css={LATEXML_URL_BASE}/css/arxiv-html-papers-20250916.css",
         "--javascript=https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js",

--- a/conversion-container/dockerfiles/Dockerfile.ar5ivist_base
+++ b/conversion-container/dockerfiles/Dockerfile.ar5ivist_base
@@ -58,7 +58,7 @@ RUN eval $(perl -I$HOME/perl5/lib -Mlocal::lib)
 RUN echo 'eval "$(perl -I$HOME/perl5/lib/perl5 -Mlocal::lib)"' >> ~/.bashrc
 
 # Collect the extended ar5iv-bindings files
-ENV AR5IV_BINDINGS_COMMIT=14d0e8faa9bddb128a00ce298b6c2f5c8445e654
+ENV AR5IV_BINDINGS_COMMIT=31cd414724679cbb4bf9aa77505e40042ed2c537
 RUN rm -rf /opt/ar5iv-bindings
 RUN git clone https://github.com/dginev/ar5iv-bindings /opt/ar5iv-bindings
 WORKDIR /opt/ar5iv-bindings
@@ -67,7 +67,7 @@ RUN git reset --hard $AR5IV_BINDINGS_COMMIT
 # Install LaTeXML, at a fixed commit, via cpanminus
 RUN mkdir -p /opt/latexml
 WORKDIR /opt/latexml
-ENV LATEXML_COMMIT=d2198ae09bc7037b987b8cf6247967ab40fd960a
+ENV LATEXML_COMMIT=b36bda7e6a677f5e232ec85eaef73c338e56669a
 RUN cpanm --notest --verbose --build-args formats https://github.com/arXiv/LaTeXML/archive/${LATEXML_COMMIT}.zip
 
 # Enable imagemagick policy permissions for work with arXiv PDF/EPS files


### PR DESCRIPTION
This tracks the final (velocity) preview candidate of LaTeXML for 12.2025.

The latexml commit has been tested with two arXiv sandboxes.
 - [Full changeset documentation](https://github.com/arXiv/LaTeXML/blob/b36bda7e6a677f5e232ec85eaef73c338e56669a/ARXIV_CHANGELOG.md)

The ar5iv-bindings commit newly includes a couple of quality of life enhancements:

- https://github.com/dginev/ar5iv-bindings/pull/11
- https://github.com/dginev/ar5iv-bindings/pull/14
- https://github.com/dginev/ar5iv-bindings/pull/13