### PR TITLE
enlarge limits for ImageMagick to handle larger assets in 2026

### DIFF
--- a/conversion-container/dockerfiles/Dockerfile.ar5ivist_base
+++ b/conversion-container/dockerfiles/Dockerfile.ar5ivist_base
@@ -58,7 +58,7 @@ RUN eval $(perl -I$HOME/perl5/lib -Mlocal::lib)
 RUN echo 'eval "$(perl -I$HOME/perl5/lib/perl5 -Mlocal::lib)"' >> ~/.bashrc
 
 # Collect the extended ar5iv-bindings files
-ENV AR5IV_BINDINGS_COMMIT=31cd414724679cbb4bf9aa77505e40042ed2c537
+ENV AR5IV_BINDINGS_COMMIT=82e0b50779c13a95f61fb2aa5b56e80908a1f9b5
 RUN rm -rf /opt/ar5iv-bindings
 RUN git clone https://github.com/dginev/ar5iv-bindings /opt/ar5iv-bindings
 WORKDIR /opt/ar5iv-bindings
@@ -73,16 +73,16 @@ RUN cpanm --notest --verbose --build-args formats https://github.com/arXiv/LaTeX
 # Enable imagemagick policy permissions for work with arXiv PDF/EPS files
 RUN perl -pi.bak -e 's/rights="none" pattern="([XE]?PS\d?|PDF)"/rights="read|write" pattern="$1"/g' /etc/ImageMagick-6/policy.xml
 # Extend imagemagick resource allowance to be able to create with high-quality images
-RUN perl -pi.bak -e 's/policy domain="resource" name="width" value="(\w+)"/policy domain="resource" name="width" value="126KP"/' /etc/ImageMagick-6/policy.xml
-RUN perl -pi.bak -e 's/policy domain="resource" name="height" value="(\w+)"/policy domain="resource" name="height" value="126KP"/' /etc/ImageMagick-6/policy.xml
-RUN perl -pi.bak -e 's/policy domain="resource" name="area" value="(\w+)"/policy domain="resource" name="area" value="2GiB"/' /etc/ImageMagick-6/policy.xml
-RUN perl -pi.bak -e 's/policy domain="resource" name="disk" value="(\w+)"/policy domain="resource" name="disk" value="8GiB"/' /etc/ImageMagick-6/policy.xml
-RUN perl -pi.bak -e 's/policy domain="resource" name="memory" value="(\w+)"/policy domain="resource" name="memory" value="2GiB"/' /etc/ImageMagick-6/policy.xml
-RUN perl -pi.bak -e 's/policy domain="resource" name="map" value="(\w+)"/policy domain="resource" name="map" value="2GiB"/' /etc/ImageMagick-6/policy.xml
+RUN perl -pi.bak -e 's/policy domain="resource" name="width" value="(\w+)"/policy domain="resource" name="width" value="256KP"/' /etc/ImageMagick-6/policy.xml
+RUN perl -pi.bak -e 's/policy domain="resource" name="height" value="(\w+)"/policy domain="resource" name="height" value="256KP"/' /etc/ImageMagick-6/policy.xml
+RUN perl -pi.bak -e 's/policy domain="resource" name="area" value="(\w+)"/policy domain="resource" name="area" value="4GiB"/' /etc/ImageMagick-6/policy.xml
+RUN perl -pi.bak -e 's/policy domain="resource" name="disk" value="(\w+)"/policy domain="resource" name="disk" value="6GiB"/' /etc/ImageMagick-6/policy.xml
+RUN perl -pi.bak -e 's/policy domain="resource" name="memory" value="(\w+)"/policy domain="resource" name="memory" value="4GiB"/' /etc/ImageMagick-6/policy.xml
+RUN perl -pi.bak -e 's/policy domain="resource" name="map" value="(\w+)"/policy domain="resource" name="map" value="4GiB"/' /etc/ImageMagick-6/policy.xml
 
-ENV MAGICK_DISK_LIMIT=2GiB
-ENV MAGICK_MEMORY_LIMIT=512MiB
-ENV MAGICK_MAP_LIMIT=1GiB
+ENV MAGICK_DISK_LIMIT=6GiB
+ENV MAGICK_MEMORY_LIMIT=4GiB
+ENV MAGICK_MAP_LIMIT=4GiB
 ENV MAGICK_TIME_LIMIT=900
 ENV MAGICK_TMPDIR=/tmp
 ENV TMPDIR=/tmp


### PR DESCRIPTION
This PR lifts the avaiable space to ImageMagick's cache to 4GiB. Intended to deploy together with an average allocation of 2GiB per latexml worker, and a min overall machine memory limit of 8GiB.

Somewhat empirical to get right, as usual.

