### PR TITLE
Reorganize link refs without <base>; consolidate JS and CSS

### DIFF
--- a/conversion-container/conversion/config.py
+++ b/conversion-container/conversion/config.py
@@ -23,6 +23,6 @@ class Settings(BaseSettings):
     IS_DEV: bool = True
     IS_FULL_CORPUS_CONVERT_MACHINE: bool = False
 
-    LOCAL_CONVERSION_DIR = "/arxiv/extracted/"
-    LOCAL_PUBLISH_DIR = "/arxiv/publish/"
+    LOCAL_CONVERSION_DIR: str = "/arxiv/extracted/"
+    LOCAL_PUBLISH_DIR: str = "/arxiv/publish/"
     LOCK_DIR: str = "/arxiv/locks/"

--- a/conversion-container/conversion/processes/convert/__init__.py
+++ b/conversion-container/conversion/processes/convert/__init__.py
@@ -9,7 +9,7 @@ from ...domain.conversion import ConversionPayload, DocumentConversionPayload
 from ...locking import id_lock
 from ...services.db import write_failure, write_start, write_success
 from ...services.files import get_file_manager
-from ...services.latexml import insert_base_tag, latexml, replace_relative_anchors
+from ...services.latexml import latexml, add_prefix_to_relative_links
 from ...services.latexml.metadata import generate_metadata_convert
 
 logger = logging.getLogger()
@@ -43,9 +43,8 @@ def process(payload: ConversionPayload) -> None:
 
             if isinstance(payload, DocumentConversionPayload):
                 main_html_file_path = f"{get_file_manager().latexml_output_dir_name(payload)}{payload.name}.html"
-                insert_base_tag(payload.identifier.idv, main_html_file_path)
-                replace_relative_anchors(
-                    f'{current_app.config["VIEW_DOC_BASE"]}/html/{payload.identifier.idv}', main_html_file_path
+                add_prefix_to_relative_links(
+                    payload.identifier.idv, main_html_file_path
                 )
                 logger.info(f"Successfully updated HTML for {payload}")
             if latexml_output.returncode == 0:

--- a/conversion-container/conversion/processes/publish/__init__.py
+++ b/conversion-container/conversion/processes/publish/__init__.py
@@ -11,9 +11,8 @@ from flask import current_app
 from ...domain.publish import PublishPayload
 from ...services.db import get_submission_with_html, write_published_html
 from ...services.files import get_file_manager
-from ...services.latexml import insert_base_tag, replace_relative_anchors
+from ...services.latexml import add_prefix_to_relative_links
 
-# from ..convert import insert_base_tag, replace_absolute_anchors_for_doc
 from ...services.latexml.metadata import generate_metadata_publish
 from .fastly_purge import fastly_purge_abs
 
@@ -35,8 +34,7 @@ def publish (payload: PublishPayload) -> None:
 
         main_html_file_path = f'{get_file_manager().local_publish_store.prefix}{payload.paper_id.idv}/{payload.paper_id.idv}.html'
 
-        insert_base_tag(payload.paper_id.idv, main_html_file_path)        
-        replace_relative_anchors(f'{current_app.config["VIEW_DOC_BASE"]}/html/{payload.paper_id.idv}', main_html_file_path)
+        add_prefix_to_relative_links(payload.paper_id.idv, main_html_file_path)
         logger.info(f'Successfully updated HTML for {payload}')
         
         submission_metadata = get_file_manager().local_publish_store.to_obj(f'{payload.paper_id.idv}/__metadata.json')

--- a/conversion-container/conversion/services/latexml/__init__.py
+++ b/conversion-container/conversion/services/latexml/__init__.py
@@ -74,7 +74,9 @@ def clean_up_stale_assets(tmpdir: Path, stale_asset_expiration_sec: int) -> None
 
 
 def latexml(payload: ConversionPayload, workdir: Path) -> LaTeXMLOutput:
-    LATEXML_URL_BASE = current_app.config["LATEXML_URL_BASE"]
+    LATEXML_URL_BASE = current_app.config.get("LATEXML_URL_BASE", "")
+    assert LATEXML_URL_BASE.startswith("/") or LATEXML_URL_BASE.startswith("http"), \
+        f"The base URL '{LATEXML_URL_BASE}' needs to be either absolute or relative to root, or it will get rewritten"
     LATEXML_PATHS = current_app.config.get(
         "LATEXML_PATHS",
         [
@@ -82,6 +84,9 @@ def latexml(payload: ConversionPayload, workdir: Path) -> LaTeXMLOutput:
             "/opt/ar5iv-bindings/supported_originals",
         ],
     )
+    # Note that the ar5iv.sty preload contains additional config that touches up the produced
+    # HTML output for a typical arXiv article, as well as adds typical resource limits internal to
+    # the conversion pass.
     LATEXML_PRELOADS = current_app.config.get("LATEXML_PRELOADS", ["ar5iv.sty"])
     LATEXML_LOG_FILE = current_app.config.get("LATEXML_LOG_FILE", "__stdout.txt")
     LATEXML_TIMEOUT_SEC = int(current_app.config.get("LATEXML_TIMEOUT_SEC", 540))
@@ -99,18 +104,15 @@ def latexml(payload: ConversionPayload, workdir: Path) -> LaTeXMLOutput:
 
     latexml_config = [
         "latexmlc",
+        "--whatsin=directory",
         "--pmml",
         "--mathtex",
         "--noinvisibletimes",
-        f"--timeout={LATEXML_TIMEOUT_SEC}",
         "--format=html5",
-        f"--css={LATEXML_URL_BASE}/css/arxiv-html-papers-20250916.css",
-        "--javascript=https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js",
-        "--javascript=https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.3.3/html2canvas.min.js",
-        f"--javascript={LATEXML_URL_BASE}/js/addons_new.js",
-        f"--javascript={LATEXML_URL_BASE}/js/feedbackOverlay.js",
         "--navigationtoc=context",
-        "--whatsin=directory",
+        f"--timeout={LATEXML_TIMEOUT_SEC}",
+        f"--css={LATEXML_URL_BASE}/css/arxiv-html-papers-20260131.css",
+        f"--javascript={LATEXML_URL_BASE}/js/arxiv-html-papers-20260131.js",
         f"--source={workdir}",
         f"--log={log_path}",
         f"--dest={output_path}",
@@ -143,27 +145,12 @@ def latexml(payload: ConversionPayload, workdir: Path) -> LaTeXMLOutput:
         returncode=returncode,
     )
 
+ANCHOR_REGEX = re.compile(r'\b(href|src|data)\s*=\s*"(?![/#])(?!http)(?!data:)', re.IGNORECASE)
 
-def insert_base_tag(idv: str, html_file_path: str) -> None:
-    """Insert the base tag into the html so we can use the /html/arxiv_id url."""
-    base_html = f'<base href="/html/{idv}/">'
-
+def add_prefix_to_relative_links(prefix: str, html_file_path: str) -> None:
+    """Add a given prefix to all relative links in an HTML file."""
     with open(html_file_path, "r+") as html:
-        soup = BeautifulSoup(html.read(), "html.parser")
-        if soup.head:
-            soup.head.append(BeautifulSoup(base_html, "html.parser"))
-            html.truncate(0)
-            html.seek(0)
-            html.write(str(soup))
-
-
-def replace_relative_anchors(absolute_base: str, html_file_path: str) -> None:
-    """Replace all the relative anchor tags with absolute anchors."""
-    # Note: If this causes bugs, use a SAX parser to do this more accurately
-    # while still not needing to completely rebuild the DOM in memory with bs4
-    ANCHOR_REGEX = re.compile(r'href="#')
-    with open(html_file_path, "r+") as html:
-        new_text = re.sub(ANCHOR_REGEX, f'href="{absolute_base}#', html.read())
+        new_text = re.sub(ANCHOR_REGEX, rf'\1="{prefix}/', html.read())
         html.truncate(0)
         html.seek(0)
         html.write(new_text)

--- a/conversion-container/dockerfiles/Dockerfile.ar5ivist_base
+++ b/conversion-container/dockerfiles/Dockerfile.ar5ivist_base
@@ -67,7 +67,7 @@ RUN git reset --hard $AR5IV_BINDINGS_COMMIT
 # Install LaTeXML, at a fixed commit, via cpanminus
 RUN mkdir -p /opt/latexml
 WORKDIR /opt/latexml
-ENV LATEXML_COMMIT=92c2631addc3e38e474abb5586e081b626dba678
+ENV LATEXML_COMMIT=9b6a4cc5ff262ffd1850091ee4c89a6929802ec4
 RUN cpanm --notest --verbose --build-args formats https://github.com/arXiv/LaTeXML/archive/${LATEXML_COMMIT}.zip
 
 # Enable imagemagick policy permissions for work with arXiv PDF/EPS files


### PR DESCRIPTION
### Scaffold reorganization of HTML Papers, worker component

The latexml worker marks the "generation phase" of an HTML article. As such, this phase is ideal for enacting adjustments to the content of an article and the HTML dialect conventions. 

The Trade-off of changes done during the generation phase:
 - do once, save in bucket, reuse on each request without additional costs or app complexity
 - any changes require a full latexml rerun, expensive to refresh

### Changes
  - Use the official LaTeXML id and linking scheme, avoid the `<base>` tag
  - Adapt to arXiv asset locations - rewrite relative links to assets to point a level underneath the `/html/id` article path.
  - Do not add any concrete JS or CSS inclusions during generations as they are expensive to reorganize later (see trade-offs)
  - Instead, add a single versioned JS asset, and a single versioned CSS asset, maintained at (and changeable from) arxiv-browse.

With these changes, we can continue to keep the worker focused on enacting the LaTeXML processing. Eventually most/all of the needed adaptations can become LaTeXML features (cross-referencing the open https://github.com/brucemiller/LaTeXML/issues/2356 ) 

🕙 This PR is pending an updated ToC generation in LaTeXML, to trickle in via https://github.com/brucemiller/LaTeXML/pull/2746 . I will update the commit shas for latexml when we have settled that aspect.