### PR TITLE
[HTML25-213] parametrize dev/prod for the reverse proxy templates

### DIFF
--- a/SubmitReverseProxy/dockerfiles/Dockerfile.dev
+++ b/SubmitReverseProxy/dockerfiles/Dockerfile.dev
@@ -45,9 +45,12 @@ RUN cp /lib/arxiv-base/arxiv/files/__init__.py /source/ReverseProxy/files.py
 
 # We track the master branch which is deployed in production, where
 # where arxiv-browse has a workflow to redeploy this proxy service when master is updated.
+
+ENV BROWSE_DEV_BRANCH=develop
+
 WORKDIR /lib
 RUN rm -rf /lib/arxiv-browse
-RUN git clone --depth 1 https://github.com/arXiv/arxiv-browse.git
+RUN git clone -b $BROWSE_DEV_BRANCH --depth 1 https://github.com/arXiv/arxiv-browse.git
 WORKDIR /lib/arxiv-browse
 # We only need the templates and transformation pipeline here.
 RUN mkdir -p /source/ReverseProxy/templates/dissemination

--- a/SubmitReverseProxy/dockerfiles/Dockerfile.prod
+++ b/SubmitReverseProxy/dockerfiles/Dockerfile.prod
@@ -1,0 +1,63 @@
+# syntax=docker/dockerfile:1
+
+FROM python:3.11.8-bookworm
+
+RUN apt-get update -y && apt-get install git -y
+RUN python -m pip install --upgrade pip
+
+
+########## INSTALL arxiv_auth ##########
+
+WORKDIR /lib
+
+ENV ARXIV_AUTH_COMMIT=6f5b3e7a61cceb35483badd3901056004ea3aa66
+RUN rm -rf /lib/arxiv-auth
+RUN git clone https://github.com/arXiv/arxiv-auth.git
+WORKDIR /lib/arxiv-auth
+RUN git reset --hard $ARXIV_AUTH_COMMIT
+
+WORKDIR /lib/arxiv-auth/arxiv-auth
+RUN python -m pip install .
+
+########## INSTALL OTHER DEPENDENCIES ##########
+
+RUN python -m pip install flask==2.2.5 werkzeug==2.3.7 pydantic==1.10.13 google-cloud-pubsub google-cloud-storage gunicorn google-cloud-logging flask_CORS pg8000
+
+########## COPY PROXY APP SOURCE ##########
+
+RUN rm -rf /source/ReverseProxy
+WORKDIR /source
+
+COPY . .
+
+######### GET BASE ARXIV.FILES UTILITY ##########
+
+ENV ARXIV_BASE_COMMIT=a1fed38fcae2d8630acc9aa8b53c2f4a1776f5c5
+
+WORKDIR /lib
+RUN rm -rf /lib/arxiv-base
+RUN git clone https://github.com/arXiv/arxiv-base.git
+WORKDIR /lib/arxiv-base
+RUN git reset --hard $ARXIV_BASE_COMMIT
+RUN cp /lib/arxiv-base/arxiv/files/__init__.py /source/ReverseProxy/files.py
+
+########## GET BROWSE TEMPLATE RESOURCES ##########
+
+# We track the master branch which is deployed in production, where
+# where arxiv-browse has a workflow to redeploy this proxy service when master is updated.
+ENV BROWSE_PROD_BRANCH=master
+WORKDIR /lib
+RUN rm -rf /lib/arxiv-browse
+RUN git clone -b $BROWSE_PROD_BRANCH --depth 1 https://github.com/arXiv/arxiv-browse.git
+WORKDIR /lib/arxiv-browse
+# We only need the templates and transformation pipeline here.
+RUN mkdir -p /source/ReverseProxy/templates/dissemination
+RUN cp -r /lib/arxiv-browse/browse/templates/dissemination/article_scaffold \
+    /source/ReverseProxy/templates/dissemination/
+RUN cp -r /lib/arxiv-browse/browse/services/html_processing/scaffold.py \
+    /source/ReverseProxy/
+
+########## RUN ##########
+WORKDIR /source
+
+CMD ["gunicorn", "--bind", "0.0.0.0:8000", "-t", "600", "entry_point:app"]

--- a/cicd/cloudbuild-develop-pr-srp.yaml
+++ b/cicd/cloudbuild-develop-pr-srp.yaml
@@ -11,6 +11,8 @@ steps:
       - 'gcr.io/$PROJECT_ID/html-submit-reverse-proxy:$COMMIT_SHA'
       - '-t'
       - 'gcr.io/$PROJECT_ID/html-submit-reverse-proxy:latest'
+      - '-f'
+      - './SubmitReverseProxy/dockerfiles/Dockerfile.dev'
       - './SubmitReverseProxy/'
   - name: 'gcr.io/cloud-builders/docker'
     args:

--- a/cicd/cloudbuild-master-pr-srp.yaml
+++ b/cicd/cloudbuild-master-pr-srp.yaml
@@ -11,6 +11,8 @@ steps:
       - 'gcr.io/$PROJECT_ID/html-submit-reverse-proxy:$COMMIT_SHA'
       - '-t'
       - 'gcr.io/$PROJECT_ID/html-submit-reverse-proxy:latest'
+      - '-f'
+      - './SubmitReverseProxy/dockerfiles/Dockerfile.prod'
       - './SubmitReverseProxy/'
   - name: 'gcr.io/cloud-builders/docker'
     args:


### PR DESCRIPTION
Follows the `conversion-container` Dockerfile setup for consistency.

The reverse proxy will now also track the head of the develop branch of arxiv-browse in the dev deploys.