### PR TITLE
Restore HTML paper rendering in the submit reverse proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -166,3 +166,8 @@ transition_converted.py
 credentials
 
 .VSCodeCounter/
+# Vendored into SubmitReverseProxy at image build time (see dockerfiles/Dockerfile.*)
+SubmitReverseProxy/ReverseProxy/files.py
+SubmitReverseProxy/ReverseProxy/scaffold.py
+SubmitReverseProxy/ReverseProxy/*_version.txt
+SubmitReverseProxy/ReverseProxy/templates/

--- a/SubmitReverseProxy/ReverseProxy/config.py
+++ b/SubmitReverseProxy/ReverseProxy/config.py
@@ -33,3 +33,21 @@ REPROCESS_SUBMISSION_TOPIC = os.environ.get('REPROCESS_SUBMISSION_TOPIC', 'html-
 
 SITES_DIR = '/source/ReverseProxy/sites/'
 TARS_DIR = '/source/ReverseProxy/downloads/'
+
+# The shared `base/footer.html` is vendored from arxiv-base master (see dockerfiles/), but the
+# `arxiv-base` that `arxiv-auth` pins is old enough that its external URL map still sends these
+# to arxiv.org. Those still reach the reader, though only via a 301 to info.arxiv.org and then
+# a 404 page whose JS appends the `.html`. Master's table links straight at the final page, so
+# take it from there (arxiv/base/config.py URLS, with HELP_SERVER resolved) and render the
+# footer arxiv-browse renders. Only the endpoints that footer actually uses are listed.
+HELP_SERVER = 'info.arxiv.org'
+URLS = [
+    ('a11y', '/help/web_accessibility.html', HELP_SERVER),
+    ('about', '/about', HELP_SERVER),
+    ('acknowledgment', '/about/ourmembers.html', HELP_SERVER),
+    ('contact', '/help/contact.html', HELP_SERVER),
+    ('copyright', '/help/license/index.html', HELP_SERVER),
+    ('help', '/help', HELP_SERVER),
+    ('privacy_policy', '/help/policies/privacy_policy.html', HELP_SERVER),
+    ('subscribe', '/help/subscribe', HELP_SERVER),
+]

--- a/SubmitReverseProxy/ReverseProxy/scaffold_response.py
+++ b/SubmitReverseProxy/ReverseProxy/scaffold_response.py
@@ -5,8 +5,9 @@ from typing import Any, Dict, Optional, Tuple
 import json
 import logging
 import os
-from flask import Response, make_response, stream_with_context
+from flask import Flask, Response, make_response, stream_with_context
 
+from arxiv.base.urls import register_external_urls
 from arxiv.files import LocalFileObj
 from .scaffold import ArticleScaffoldMetadata, HTMLFileTransform, render_branded_html_paper
 
@@ -92,6 +93,19 @@ BROWSE_VERSION = os.environ.get('BROWSE_VERSION') or _vendored_version('browse',
 # arxiv-base serves the shared chrome from /static/base/<BASE_VERSION>, see arxiv/base/config.py,
 # where it defaults to the installed distribution version, i.e. the one in its pyproject.toml.
 ARXIV_BASE_VERSION = os.environ.get('ARXIV_BASE_VERSION') or _vendored_version('arxiv_base', '1.0.1')
+
+def register_scaffold_urls(app: Flask) -> None:
+    """Teach `app` to build every URL the vendored scaffold templates ask for.
+
+    The vendored arxiv-base `base/footer.html` links to the info site via named endpoints
+    (about, help, contact, ...) which only exist in arxiv-base's external URL map. That is the
+    part of `Base(app)` we need; the rest of that blueprint is too old here to be worth wiring.
+    It is registered first so `browse_urls_fallback` stays the handler of last resort, and can
+    keep logging only the endpoints that nothing at all could build.
+    """
+    register_external_urls(app)
+    app.url_build_error_handlers.append(browse_urls_fallback)
+
 
 def browse_urls_fallback(error: Exception, endpoint: str, values: Dict[str, Any]) -> Optional[str]:
     if endpoint == "static":

--- a/SubmitReverseProxy/ReverseProxy/scaffold_response.py
+++ b/SubmitReverseProxy/ReverseProxy/scaffold_response.py
@@ -1,17 +1,38 @@
 from datetime import timezone
 from email.utils import format_datetime
 from pathlib import Path
+from typing import Any, Dict, Optional, Tuple
 import json
 import logging
+import os
 from flask import Response, make_response, stream_with_context
 
 from arxiv.files import LocalFileObj
 from .scaffold import ArticleScaffoldMetadata, HTMLFileTransform, render_branded_html_paper
 
 
+def safe_render_branded_html_paper(byte_line: bytes, state: str, meta: ArticleScaffoldMetadata) \
+        -> Tuple[str, bytes]:
+    """Never let a scaffolding failure truncate the paper.
+
+    The scaffold templates are vendored from arxiv-browse at build time, so they can grow
+    dependencies this service does not provide (an arxiv-base blueprint, a new endpoint...).
+    Since the response is streamed, an exception raised mid-transform silently truncates the
+    page to whatever bytes were already flushed -- typically a blank body under a valid head.
+    Degrade to the unbranded LaTeXML HTML instead, and leave a loud trace in the logs.
+    """
+    try:
+        return render_branded_html_paper(byte_line, state, meta)
+    except Exception as e:
+        logging.exception(
+            f"HTML paper scaffolding failed in state {state!r}, serving unbranded HTML: {e}")
+        # 'noop' is terminal, so the remainder of the document passes through unmodified.
+        return ('noop', byte_line)
+
+
 def send_file_with_scaffold(path: Path, meta: ArticleScaffoldMetadata) -> Response:
     file = LocalFileObj(path)
-    transformed = HTMLFileTransform(file, render_branded_html_paper, meta)
+    transformed = HTMLFileTransform(file, safe_render_branded_html_paper, meta)
     # This logic matches the basics of arxiv-browse's
     # dissemination.default_resp_fn , followed by a scaffolding transform on the content.
     resp: Response = Response()
@@ -50,11 +71,37 @@ def submission_scaffold_metadata(submission_id : int, metadata_path : Path) -> A
             date_of_version = None
         )
 
-BROWSE_VERSION = '0.3.4' # Move this to Dockerfile ?
+def _vendored_version(name: str, fallback: str) -> str:
+    """The release the vendored `name` templates were copied from.
 
-def browse_urls_fallback(error, endpoint, values):
+    Both projects serve their assets from a versioned path, so the Dockerfile bakes the
+    version out of the very same checkout it copies the templates from -- markup and assets
+    then cannot drift apart. It has to come from the checkout rather than from
+    `importlib.metadata`, because the `arxiv-base` actually installed here is the older one
+    `arxiv-auth` pins, not the one the templates came from.
+    """
+    try:
+        version = Path(__file__).with_name(f'{name}_version.txt').read_text().strip()
+    except Exception as e:
+        logging.error(f"Failed to read the vendored {name} version, with {e}")
+        version = ''
+    return version or fallback
+
+# arxiv-browse serves its own assets from /static/browse/<APP_VERSION>, see browse/config.py.
+BROWSE_VERSION = os.environ.get('BROWSE_VERSION') or _vendored_version('browse', '0.3.4')
+# arxiv-base serves the shared chrome from /static/base/<BASE_VERSION>, see arxiv/base/config.py,
+# where it defaults to the installed distribution version, i.e. the one in its pyproject.toml.
+ARXIV_BASE_VERSION = os.environ.get('ARXIV_BASE_VERSION') or _vendored_version('arxiv_base', '1.0.1')
+
+def browse_urls_fallback(error: Exception, endpoint: str, values: Dict[str, Any]) -> Optional[str]:
     if endpoint == "static":
+        # `services.arxiv.org` does route /static/browse/, so keep this one relative.
         return f"/static/browse/{BROWSE_VERSION}/{values.get('filename')}"
+    elif endpoint == "base.static":
+        # It does not route /static/base/ though, and this service never registers the
+        # arxiv-base blueprint that would serve it -- so link the shared chrome assets off
+        # the static host, the same one the conversion pipeline already uses.
+        return f"https://static.arxiv.org/static/base/{ARXIV_BASE_VERSION}/{values.get('filename')}"
     else:
         logging.error(f"URL build error for endpoint {endpoint} with values {values}")
         return None

--- a/SubmitReverseProxy/dockerfiles/Dockerfile.dev
+++ b/SubmitReverseProxy/dockerfiles/Dockerfile.dev
@@ -59,6 +59,25 @@ RUN cp -r /lib/arxiv-browse/browse/templates/dissemination/article_scaffold \
     /source/ReverseProxy/templates/dissemination/
 RUN cp -r /lib/arxiv-browse/browse/services/html_processing/scaffold.py \
     /source/ReverseProxy/
+# Their CSS/JS/images are served off /static/browse/<APP_VERSION>, so take the version from
+# the very same checkout the templates come from, see BROWSE_VERSION in scaffold_response.py.
+RUN sed -n 's/^ *APP_VERSION *: *str *= *"\(.*\)"/\1/p' /lib/arxiv-browse/browse/config.py \
+    | head -1 > /source/ReverseProxy/browse_version.txt \
+    && test -s /source/ReverseProxy/browse_version.txt
+
+# The scaffold also includes arxiv-base's shared header/footer chrome
+# (`base/announcement_banner.html`, `base/footer.html`), which arxiv-browse gets from
+# `Base(app)`. The `arxiv-base` that `arxiv-auth` pins predates that chrome, so take it
+# from the clone above -- refreshed to master, which arxiv-browse pins on develop too, so
+# scaffold and chrome always come from the pair of commits browse itself renders with.
+WORKDIR /lib/arxiv-base
+RUN git fetch --depth 1 origin master && git checkout -f FETCH_HEAD
+RUN cp -r /lib/arxiv-base/arxiv/base/templates/base /source/ReverseProxy/templates/
+# Their CSS/JS/images are served off static.arxiv.org under this version, see
+# ARXIV_BASE_VERSION in scaffold_response.py.
+RUN sed -n 's/^version *= *"\(.*\)"/\1/p' /lib/arxiv-base/pyproject.toml \
+    | head -1 > /source/ReverseProxy/arxiv_base_version.txt \
+    && test -s /source/ReverseProxy/arxiv_base_version.txt
 
 ########## RUN ##########
 WORKDIR /source

--- a/SubmitReverseProxy/dockerfiles/Dockerfile.dev
+++ b/SubmitReverseProxy/dockerfiles/Dockerfile.dev
@@ -79,6 +79,14 @@ RUN sed -n 's/^version *= *"\(.*\)"/\1/p' /lib/arxiv-base/pyproject.toml \
     | head -1 > /source/ReverseProxy/arxiv_base_version.txt \
     && test -s /source/ReverseProxy/arxiv_base_version.txt
 
+########## CHECK THE VENDORED SCAFFOLD STILL RENDERS ##########
+
+# Everything above is fetched from other repositories at build time, so this is the earliest
+# point an upstream change can be caught. Without it the breakage reaches the reader as a
+# truncated, unbranded, or blank page, since the response is streamed.
+WORKDIR /source
+RUN PYTHONPATH=/source python tests/scaffold_smoke.py
+
 ########## RUN ##########
 WORKDIR /source
 

--- a/SubmitReverseProxy/dockerfiles/Dockerfile.prod
+++ b/SubmitReverseProxy/dockerfiles/Dockerfile.prod
@@ -58,6 +58,25 @@ RUN cp -r /lib/arxiv-browse/browse/templates/dissemination/article_scaffold \
     /source/ReverseProxy/templates/dissemination/
 RUN cp -r /lib/arxiv-browse/browse/services/html_processing/scaffold.py \
     /source/ReverseProxy/
+# Their CSS/JS/images are served off /static/browse/<APP_VERSION>, so take the version from
+# the very same checkout the templates come from, see BROWSE_VERSION in scaffold_response.py.
+RUN sed -n 's/^ *APP_VERSION *: *str *= *"\(.*\)"/\1/p' /lib/arxiv-browse/browse/config.py \
+    | head -1 > /source/ReverseProxy/browse_version.txt \
+    && test -s /source/ReverseProxy/browse_version.txt
+
+# The scaffold also includes arxiv-base's shared header/footer chrome
+# (`base/announcement_banner.html`, `base/footer.html`), which arxiv-browse gets from
+# `Base(app)`. The `arxiv-base` that `arxiv-auth` pins predates that chrome, so take it
+# from the clone above -- refreshed to master, which is what arxiv-browse pins too, so
+# scaffold and chrome always come from the pair of commits browse itself renders with.
+WORKDIR /lib/arxiv-base
+RUN git fetch --depth 1 origin master && git checkout -f FETCH_HEAD
+RUN cp -r /lib/arxiv-base/arxiv/base/templates/base /source/ReverseProxy/templates/
+# Their CSS/JS/images are served off static.arxiv.org under this version, see
+# ARXIV_BASE_VERSION in scaffold_response.py.
+RUN sed -n 's/^version *= *"\(.*\)"/\1/p' /lib/arxiv-base/pyproject.toml \
+    | head -1 > /source/ReverseProxy/arxiv_base_version.txt \
+    && test -s /source/ReverseProxy/arxiv_base_version.txt
 
 ########## RUN ##########
 WORKDIR /source

--- a/SubmitReverseProxy/dockerfiles/Dockerfile.prod
+++ b/SubmitReverseProxy/dockerfiles/Dockerfile.prod
@@ -78,6 +78,14 @@ RUN sed -n 's/^version *= *"\(.*\)"/\1/p' /lib/arxiv-base/pyproject.toml \
     | head -1 > /source/ReverseProxy/arxiv_base_version.txt \
     && test -s /source/ReverseProxy/arxiv_base_version.txt
 
+########## CHECK THE VENDORED SCAFFOLD STILL RENDERS ##########
+
+# Everything above is fetched from other repositories at build time, so this is the earliest
+# point an upstream change can be caught. Without it the breakage reaches the reader as a
+# truncated, unbranded, or blank page, since the response is streamed.
+WORKDIR /source
+RUN PYTHONPATH=/source python tests/scaffold_smoke.py
+
 ########## RUN ##########
 WORKDIR /source
 

--- a/SubmitReverseProxy/entry_point.py
+++ b/SubmitReverseProxy/entry_point.py
@@ -12,20 +12,13 @@ import ReverseProxy.files
 #
 # ruff: noqa: E402
 sys.modules["arxiv.files"] = ReverseProxy.files 
-from arxiv.base.urls import register_external_urls
-from ReverseProxy.scaffold_response import browse_urls_fallback
+from ReverseProxy.scaffold_response import register_scaffold_urls
 from ReverseProxy.factory import create_web_app
 
 app = create_web_app()
 
-# The vendored arxiv-base `base/footer.html` links to the info site via named endpoints
-# (about, help, contact, ...) which only exist in arxiv-base's external URL map. This is the
-# part of `Base(app)` we need; the rest of that blueprint is too old here to be worth wiring.
-# It goes first so that `browse_urls_fallback` stays the handler of last resort, and can keep
-# logging the endpoints that nothing at all could build.
-register_external_urls(app)
-
-app.url_build_error_handlers.append(browse_urls_fallback)
+# tests/scaffold_smoke.py wires a bare app the same way, so keep this a single call.
+register_scaffold_urls(app)
 
 if __name__=='__main__':
     app.run(debug=False)

--- a/SubmitReverseProxy/entry_point.py
+++ b/SubmitReverseProxy/entry_point.py
@@ -12,10 +12,18 @@ import ReverseProxy.files
 #
 # ruff: noqa: E402
 sys.modules["arxiv.files"] = ReverseProxy.files 
+from arxiv.base.urls import register_external_urls
 from ReverseProxy.scaffold_response import browse_urls_fallback
 from ReverseProxy.factory import create_web_app
 
 app = create_web_app()
+
+# The vendored arxiv-base `base/footer.html` links to the info site via named endpoints
+# (about, help, contact, ...) which only exist in arxiv-base's external URL map. This is the
+# part of `Base(app)` we need; the rest of that blueprint is too old here to be worth wiring.
+# It goes first so that `browse_urls_fallback` stays the handler of last resort, and can keep
+# logging the endpoints that nothing at all could build.
+register_external_urls(app)
 
 app.url_build_error_handlers.append(browse_urls_fallback)
 

--- a/SubmitReverseProxy/tests/fixtures/latexml_paper.html
+++ b/SubmitReverseProxy/tests/fixtures/latexml_paper.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>A smoke test paper</title>
+<link rel="stylesheet" href="/static/browse/0.3.4/css/latexml_styles.css">
+</head>
+<body>
+<nav class="ltx_page_navbar">
+<nav class="ltx_TOC"></nav>
+</nav>
+<div class="ltx_page_main">
+<div class="ltx_page_content">
+<article class="ltx_document">
+<p>Body content.</p>
+</article>
+</div>
+<footer class="ltx_page_footer">
+<div class="ltx_page_logo">Generated on a smoke test by LaTeXML</div></footer>
+</div>
+</body>
+</html>

--- a/SubmitReverseProxy/tests/scaffold_smoke.py
+++ b/SubmitReverseProxy/tests/scaffold_smoke.py
@@ -1,0 +1,93 @@
+"""Check that a branded HTML paper can actually be rendered, at image build time.
+
+The scaffold templates and the state machine that drives them are vendored from arxiv-browse
+and arxiv-base when the image is built, so a change upstream can break rendering here without
+a single line of this repository changing. The response is streamed, so the failure surfaces
+as a silently truncated paper rather than a 500 -- which is how it went unnoticed once already.
+
+Run as a `RUN` step in dockerfiles/Dockerfile.*, this turns that class of breakage into a
+failed build. It deliberately uses the same wiring as entry_point.py, via
+`register_scaffold_urls`, so a misordered or missing URL handler fails here too.
+"""
+import logging
+import sys
+from pathlib import Path
+
+import ReverseProxy.files
+# The same shim entry_point.py installs, see the comment there.
+sys.modules["arxiv.files"] = ReverseProxy.files
+
+from flask import Flask, render_template
+from ReverseProxy.scaffold import ArticleScaffoldMetadata
+from ReverseProxy.scaffold_response import register_scaffold_urls, safe_render_branded_html_paper
+
+FIXTURE = Path(__file__).parent / 'fixtures' / 'latexml_paper.html'
+TEMPLATES = ['head_mixins.html', 'header.html', 'callout_license.html', 'footer.html']
+
+# A failed URL build is logged rather than raised once a fallback handles it, so a page can
+# render "fine" while filling the logs. Treat any error log during rendering as a failure.
+class ErrorsAreFailures(logging.Handler):
+    def __init__(self) -> None:
+        super().__init__(level=logging.ERROR)
+        self.records: list[str] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(record.getMessage())
+
+
+def main() -> int:
+    errors = ErrorsAreFailures()
+    logging.getLogger().addHandler(errors)
+
+    app = Flask('ReverseProxy', static_folder=None)
+    app.config.from_pyfile('config.py')
+    app.config['SERVER_NAME'] = None
+    register_scaffold_urls(app)
+
+    # What routes.py builds for a submission preview, which is the only case this service has.
+    meta = ArticleScaffoldMetadata(license='CC BY 4.0', page_id='7750266', published=False,
+                                   primary_category='astro-ph.GA', date_of_version='2026-01-16')
+
+    failures = []
+    with app.test_request_context('/html/submission/7750266/view'):
+        # Every scaffold template must render on its own ...
+        rendered = {}
+        for template in TEMPLATES:
+            try:
+                rendered[template] = render_template(
+                    f'dissemination/article_scaffold/{template}', meta=meta)
+            except Exception as e:
+                failures.append(f"{template} does not render: {type(e).__name__}: {e}")
+
+        # ... and the state machine must reach the end of the document, having inserted each
+        # of them. Stalling midway is not an error, it just quietly drops the arXiv branding.
+        state, out = 'head', []
+        for line in FIXTURE.read_bytes().splitlines(keepends=True):
+            state, transformed = safe_render_branded_html_paper(line, state, meta)
+            out.append(transformed)
+        body = b''.join(out).decode('utf-8')
+
+        if state == 'noop':
+            failures.append("transform aborted into 'noop' -- either scaffolding raised and the "
+                            "guard caught it, or the fixture tripped the legacy JS passthrough")
+        elif state != 'body_end':
+            failures.append(f"transform ended in state {state!r}, expected 'body_end' -- the "
+                            f"markup the state machine looks for has moved in {FIXTURE.name}")
+        for template, content in rendered.items():
+            if content.strip() and content not in body:
+                failures.append(f"{template} is missing from the branded paper")
+        if 'Generated on a smoke test by LaTeXML' in body:
+            failures.append("the LaTeXML footer was not replaced by the arXiv one")
+
+    failures.extend(f"error logged while rendering: {message}" for message in errors.records)
+
+    for failure in failures:
+        print(f"FAIL {failure}", file=sys.stderr)
+    if failures:
+        return 1
+    print(f"scaffold smoke test OK ({len(TEMPLATES)} templates, {len(body)} bytes branded)")
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
Obligatory note: The "submit reverse proxy for HTML papers" is a temporary service meant to be phased out and entirely removed upon completing the migration of the Submission system into GCP space.

Redeployed builds served a blank page: browse's article scaffold now uses `url_for('base.static')` and includes arxiv-base's `base/footer.html`, neither of which resolves here since this service never registers `Base(app)`. The paper is streamed, so the `BuildError` truncated it after the head instead of erroring.

- vendor arxiv-base's `base/` templates from the existing clone, refreshed to master (the `ARXIV_BASE_COMMIT` pin still governs `files.py`)
- add a `base.static` branch to the URL fallback, and `register_external_urls` for the footer's named endpoints
- bake both static versions out of the checkouts the templates come from
- second commit: render the scaffold at image build time, so this class of upstream break fails the build instead of the reader's page

Verified on local builds of both dockerfiles. First end-to-end proof is the dev deploy — worth opening one submission preview before promoting to production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)